### PR TITLE
Acceptance test for attach cluster added

### DIFF
--- a/internal/resources/cluster/cluster_provider_test.go
+++ b/internal/resources/cluster/cluster_provider_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright © 2021 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+)
+
+func initTestProvider(t *testing.T) *schema.Provider {
+	testAccProvider := &schema.Provider{
+		Schema: authctx.ProviderAuthSchema(),
+		ResourcesMap: map[string]*schema.Resource{
+			ResourceName: ResourceTMCCluster(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			ResourceName: DataSourceTMCCluster(),
+		},
+		ConfigureContextFunc: authctx.ProviderConfigureContext,
+	}
+	if err := testAccProvider.InternalValidate(); err != nil {
+		require.NoError(t, err)
+	}
+
+	return testAccProvider
+}

--- a/internal/resources/cluster/config_test.go
+++ b/internal/resources/cluster/config_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright © 2021 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package cluster
+
+const testDefaultAttachClusterScript = `
+	resource {{.ResourceName}} {{.ResourceNameVar}} {
+	  management_cluster_name = "attached"
+	  provisioner_name        = "attached"
+	  name                    = "{{.Name}}"
+
+	  {{.Meta}}
+
+	  spec {
+		cluster_group = "default"
+	  }
+
+	  wait_until_ready = false
+	}
+`
+
+const testAttachClusterWithKubeConfigScript = `
+	resource {{.ResourceName}} {{.ResourceNameVar}} {
+	  management_cluster_name = "attached"
+	  provisioner_name        = "attached"
+	  name                    = "{{.Name}}"
+
+	  attach_k8s_cluster {
+		kubeconfig_file = "{{.KubeConfigPath}}"
+		description     = "optional description about the kube-config provided"
+	  }
+
+	  {{.Meta}}
+
+	  spec {
+		cluster_group = "default"
+	  }
+
+	  wait_until_ready = true
+	}
+`
+
+const testDataSourceAttachClusterScript = `
+	resource {{.ResourceName}} {{.ResourceNameVar}} {
+	  management_cluster_name = "attached"
+	  provisioner_name        = "attached"
+	  name                    = "{{.Name}}"
+
+	  {{.Meta}}
+
+	  spec {
+		cluster_group = "default"
+	  }
+
+	  wait_until_ready = false
+	}
+
+	data {{.ResourceName}} {{.DataSourceNameVar}} {
+		management_cluster_name = {{.ResourceName}}.{{.ResourceNameVar}}.management_cluster_name
+		provisioner_name        = {{.ResourceName}}.{{.ResourceNameVar}}.provisioner_name
+		name                    = {{.ResourceName}}.{{.ResourceNameVar}}.name
+	}
+`

--- a/internal/resources/cluster/data_source_cluster_test.go
+++ b/internal/resources/cluster/data_source_cluster_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2021 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+)
+
+func TestAcceptanceForAttachClusterDataSource(t *testing.T) {
+	var provider = initTestProvider(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testhelper.TestPreCheck(t),
+		ProviderFactories: testhelper.GetTestProviderFactories(provider),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testGetResourceClusterDefinition(t, withClusterName("tf-attach-test-ds"), withDataSourceScript()),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceAttributes(),
+				),
+			},
+		},
+	})
+	t.Log("cluster data source acceptance test complete!")
+}
+
+func checkDataSourceAttributes() resource.TestCheckFunc {
+	var check = []resource.TestCheckFunc{
+		verifyClusterDataSource(dataSourceName),
+		resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+	}
+
+	check = append(check, testhelper.MetaDataSourceAttributeCheck(dataSourceName, resourceName)...)
+
+	return resource.ComposeTestCheckFunc(check...)
+}
+
+func verifyClusterDataSource(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module does not have cluster resource %s", name)
+		}
+
+		return nil
+	}
+}

--- a/internal/resources/cluster/helper_test.go
+++ b/internal/resources/cluster/helper_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright © 2021 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package cluster
+
+import (
+	"bytes"
+	"os"
+	"text/template"
+
+	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+)
+
+type acceptanceTestType int
+
+const (
+	attachClusterType acceptanceTestType = iota
+	attachClusterTypeWithKubeConfig
+)
+
+type testAcceptanceOption func(config *testAcceptanceConfig)
+
+type testAcceptanceConfig struct {
+	ResourceName      string
+	ResourceNameVar   string
+	DataSourceNameVar string
+	Name              string
+	KubeConfigPath    string
+	Meta              string
+	accTestType       acceptanceTestType
+	templateData      string
+}
+
+func withClusterName(name string) testAcceptanceOption {
+	return func(config *testAcceptanceConfig) {
+		config.Name = name
+	}
+}
+
+func withKubeConfig() testAcceptanceOption {
+	return func(config *testAcceptanceConfig) {
+		config.KubeConfigPath = os.Getenv("KUBECONFIG")
+		config.accTestType = attachClusterTypeWithKubeConfig
+		config.templateData = testAttachClusterWithKubeConfigScript
+	}
+}
+
+func withDataSourceScript() testAcceptanceOption {
+	return func(config *testAcceptanceConfig) {
+		config.templateData = testDataSourceAttachClusterScript
+		config.DataSourceNameVar = clusterDataSourceVar
+	}
+}
+
+func testGetDefaultAcceptanceConfig() *testAcceptanceConfig {
+	return &testAcceptanceConfig{
+		ResourceName:    clusterResource,
+		ResourceNameVar: clusterResourceVar,
+		Meta:            testhelper.MetaTemplate,
+		accTestType:     attachClusterType,
+		templateData:    testDefaultAttachClusterScript,
+	}
+}
+
+func parse(m interface{}, objects string) (string, error) {
+	var definitionBytes bytes.Buffer
+
+	t := template.Must(template.New("script").Parse(objects))
+	if err := t.Execute(&definitionBytes, m); err != nil {
+		return "", err
+	}
+
+	return definitionBytes.String(), nil
+}

--- a/internal/resources/cluster/resource_cluster_test.go
+++ b/internal/resources/cluster/resource_cluster_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright © 2021 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
+	clustermodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+)
+
+const (
+	clusterResource      = "tmc_cluster"
+	clusterResourceVar   = "test_attach_cluster"
+	clusterDataSourceVar = "test_data_attach_cluster"
+)
+
+var (
+	resourceName   = fmt.Sprintf("%s.%s", clusterResource, clusterResourceVar)
+	dataSourceName = fmt.Sprintf("data.%s.%s", clusterResource, clusterDataSourceVar)
+)
+
+func TestAcceptanceForAttachClusterResource(t *testing.T) {
+	var provider = initTestProvider(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testhelper.TestPreCheck(t),
+		ProviderFactories: testhelper.GetTestProviderFactories(provider),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testGetResourceClusterDefinition(t, withClusterName("tf-attach-test")),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceAttributes(provider, "tf-attach-test"),
+				),
+			},
+			{
+				Config: testGetResourceClusterDefinition(t, withClusterName("tf-attach-kubeconfig-test"), withKubeConfig()),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceAttributes(provider, "tf-attach-kubeconfig-test"),
+				),
+			},
+		},
+	})
+	t.Log("cluster resource acceptance test complete!")
+}
+
+func testGetResourceClusterDefinition(t *testing.T, opts ...testAcceptanceOption) string {
+	templateConfig := testGetDefaultAcceptanceConfig()
+	for _, option := range opts {
+		option(templateConfig)
+	}
+
+	if templateConfig.accTestType == attachClusterTypeWithKubeConfig {
+		if templateConfig.KubeConfigPath == "" {
+			t.Skipf("KUBECONFIG env var is not set: %s", templateConfig.KubeConfigPath)
+		}
+	}
+
+	definition, err := parse(templateConfig, templateConfig.templateData)
+	if err != nil {
+		t.Skipf("unable to parse cluster script: %s", definition)
+	}
+
+	return definition
+}
+
+func checkResourceAttributes(provider *schema.Provider, clusterName string) resource.TestCheckFunc {
+	var check = []resource.TestCheckFunc{
+		verifyClusterResourceCreation(provider, resourceName, clusterName),
+		resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+		resource.TestCheckResourceAttr(resourceName, helper.GetFirstElementOf("spec", "cluster_group"), "default"),
+	}
+
+	check = append(check, testhelper.MetaResourceAttributeCheck(resourceName)...)
+
+	return resource.ComposeTestCheckFunc(check...)
+}
+
+func verifyClusterResourceCreation(
+	provider *schema.Provider,
+	resourceName string,
+	clusterName string,
+) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if provider == nil {
+			return errors.New("provider not initialised")
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return errors.Errorf("not found resource %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.Errorf("ID not set, resource %s", resourceName)
+		}
+
+		config := authctx.TanzuContext{
+			ServerEndpoint: os.Getenv(authctx.ServerEndpointEnvVar),
+			Token:          os.Getenv(authctx.CSPTokenEnvVar),
+			CSPEndPoint:    os.Getenv(authctx.CSPEndpointEnvVar),
+		}
+
+		err := config.Setup()
+		if err != nil {
+			return errors.Wrap(err, "unable to set the context")
+		}
+
+		fn := &clustermodel.VmwareTanzuManageV1alpha1ClusterFullName{
+			Name:                  clusterName,
+			ManagementClusterName: "attached",
+			ProvisionerName:       "attached",
+		}
+
+		resp, err := config.TMCConnection.ClusterResourceService.ManageV1alpha1ClusterResourceServiceGet(fn)
+		if err != nil {
+			return errors.Errorf("cluster resource not found: %s", err)
+		}
+
+		if resp == nil {
+			return errors.Errorf("cluster resource is empty, resource: %s", resourceName)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Acceptance test for attach cluster added, with and without `kubeconfig` provided. 

Attach acceptance test result:
```
--- PASS: TestFlattenSpec (0.00s)
=== RUN   TestFlattenSpec/check_for_nil_data_in_cluster_spec
    --- PASS: TestFlattenSpec/check_for_nil_data_in_cluster_spec (0.00s)
=== RUN   TestFlattenSpec/normal_scenario_with_cluster_group_and_proxy
    --- PASS: TestFlattenSpec/normal_scenario_with_cluster_group_and_proxy (0.00s)
=== RUN   TestAcceptanceForAttachClusterDataSource
    data_source_cluster_test.go:34: cluster data source acceptance test complete!
--- PASS: TestAcceptanceForAttachClusterDataSource (19.85s)
=== RUN   TestAcceptanceForAttachClusterResource
TMC resources applied to the cluster successfully
    resource_cluster_test.go:57: cluster resource acceptance test complete!
--- PASS: TestAcceptanceForAttachClusterResource (462.00s)
PASS

Process finished with exit code 0
```