### PR TITLE
Fixed node pool diff from cluster resource

### DIFF
--- a/internal/client/nodepool/nodepool_resource.go
+++ b/internal/client/nodepool/nodepool_resource.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 
 	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/transport"
-	clustermodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster"
 	nodepoolsmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 )
 
@@ -35,34 +34,6 @@ type ClientService interface {
 	ManageV1alpha1ClusterNodePoolResourceServiceDelete(fn *nodepoolsmodel.VmwareTanzuManageV1alpha1ClusterNodepoolFullName) error
 
 	ManageV1alpha1ClusterNodePoolResourceServiceUpdate(request *nodepoolsmodel.VmwareTanzuManageV1alpha1ClusterNodepoolCreateNodepoolRequest) (*nodepoolsmodel.VmwareTanzuManageV1alpha1ClusterNodepoolCreateNodepoolResponse, error)
-
-	ManageV1alpha1ClusterNodePoolSpecResourceList(fn *clustermodel.VmwareTanzuManageV1alpha1ClusterFullName) (*nodepoolsmodel.VmwareTanzuManageV1alpha1ClusterNodepoolListNodepoolsResponse, error)
-}
-
-/*
-ManageV1alpha1ClusterNodePoolSpecResourceList lists node pool.
-*/
-func (c *Client) ManageV1alpha1ClusterNodePoolSpecResourceList(
-	fn *clustermodel.VmwareTanzuManageV1alpha1ClusterFullName,
-) (*nodepoolsmodel.VmwareTanzuManageV1alpha1ClusterNodepoolListNodepoolsResponse, error) {
-	queryParams := url.Values{}
-
-	if fn.ManagementClusterName != "" {
-		queryParams["searchScope.managementClusterName"] = []string{fn.ManagementClusterName}
-	}
-
-	if fn.ProvisionerName != "" {
-		queryParams["searchScope.provisionerName"] = []string{fn.ProvisionerName}
-	}
-
-	// It is unlikely for a cluster to have more number of node pools. Hence, pagination is not unhandled
-	queryParams["includeTotalCount"] = []string{"true"}
-
-	requestURL := fmt.Sprintf("%s/%s/%s?%s", "v1alpha1/clusters", fn.Name, "nodepools", queryParams.Encode())
-	clusterNodePoolListResponse := &nodepoolsmodel.VmwareTanzuManageV1alpha1ClusterNodepoolListNodepoolsResponse{}
-	err := c.Get(requestURL, clusterNodePoolListResponse)
-
-	return clusterNodePoolListResponse, err
 }
 
 /*

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -315,8 +315,6 @@ func resourceClusterInPlaceUpdate(ctx context.Context, d *schema.ResourceData, m
 		getResp.Cluster.Spec.ClusterGroupName = incomingCGName.(string)
 	}
 
-	//TODO: check if node pool is updated, update the getResp by calling nodePool update endpoint
-
 	_, err = config.TMCConnection.ClusterResourceService.ManageV1alpha1ClusterResourceServiceUpdate(
 		&clustermodel.VmwareTanzuManageV1alpha1ClusterRequest{
 			Cluster: getResp.Cluster,


### PR DESCRIPTION
When we add a new node pool entry through node pool resource for a cluster, the cluster resource of that particular cluster states the new node pool created as a diff because the cluster resource is not aware of the node pool resource created.