### PR TITLE
Add ready_wait_timeout attribute to cluster resource

### DIFF
--- a/examples/resources/tmc_cluster/resource_attach_cluster.tf
+++ b/examples/resources/tmc_cluster/resource_attach_cluster.tf
@@ -13,5 +13,5 @@ resource "tmc_cluster" "attach_cluster_without_apply" {
     cluster_group = "default" # Default: default
   }
 
-  wait_until_ready = false
+  # The deployment link and the command needed to be run to attach this cluster would be provided in the output.status.execution_cmd
 }

--- a/examples/resources/tmc_cluster/resource_attach_cluster_kubeconfig.tf
+++ b/examples/resources/tmc_cluster/resource_attach_cluster_kubeconfig.tf
@@ -19,7 +19,5 @@ resource "tmc_cluster" "attach_cluster_with_kubeconfig" {
     cluster_group = "default" # Default: default
   }
 
-  wait_until_ready = true # Default: false, when set resource waits until 3 min for the cluster to become ready
-
-  # The deployment link and the command needed to be run to attach this cluster would be provided in the output.status.execution_cmd
+  ready_wait_timeout = "15m" # Default: waits until 3 min for the cluster to become ready
 }

--- a/examples/resources/tmc_cluster/resource_attach_cluster_proxy.tf
+++ b/examples/resources/tmc_cluster/resource_attach_cluster_proxy.tf
@@ -14,5 +14,5 @@ resource "tmc_cluster" "attach_cluster_with_proxy" {
     proxy         = "proxy-name"
   }
 
-  wait_until_ready = false
+  ready_wait_timeout = "15m" # Default: waits until 3 min for the cluster to become ready
 }

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -7,6 +7,7 @@ package helper
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -47,4 +48,15 @@ func TestGetFirstElementOf(t *testing.T) {
 			require.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+func TestRetryUntilTimeout(t *testing.T) {
+	testFun := func() (bool, error) {
+		return true, nil
+	}
+
+	retries, err := RetryUntilTimeout(testFun, 1*time.Second, 6*time.Second)
+
+	require.NoError(t, err)
+	require.Equal(t, 4, retries)
 }

--- a/internal/helper/retry.go
+++ b/internal/helper/retry.go
@@ -32,3 +32,30 @@ func Retry(f Retryable, interval time.Duration, attempts int) (int, error) {
 
 	return retries, err
 }
+
+// Retry is a wrapper to retry functions.
+func RetryUntilTimeout(f Retryable, interval time.Duration, timeout time.Duration) (int, error) {
+	var (
+		err   error
+		retry bool
+	)
+
+	timeElapsedInSeconds := 0
+
+	retries := 1
+
+	for timeElapsedInSeconds < int(timeout.Seconds()) {
+		retry, err = f()
+		if !retry {
+			break
+		}
+
+		presentBackOffInterval := (retries * int(interval.Seconds()))
+		time.Sleep(time.Duration(presentBackOffInterval) * time.Second)
+
+		timeElapsedInSeconds += presentBackOffInterval
+		retries++
+	}
+
+	return retries, err
+}

--- a/internal/resources/cluster/config_test.go
+++ b/internal/resources/cluster/config_test.go
@@ -17,7 +17,7 @@ const testDefaultAttachClusterScript = `
 		cluster_group = "default"
 	  }
 
-	  wait_until_ready = false
+	  ready_wait_timeout = "3m"
 	}
 `
 
@@ -38,7 +38,7 @@ const testAttachClusterWithKubeConfigScript = `
 		cluster_group = "default"
 	  }
 
-	  wait_until_ready = true
+	  ready_wait_timeout = "3m"
 	}
 `
 
@@ -54,7 +54,7 @@ const testDataSourceAttachClusterScript = `
 		cluster_group = "default"
 	  }
 
-	  wait_until_ready = false
+	  ready_wait_timeout = "3m"
 	}
 
 	data {{.ResourceName}} {{.DataSourceNameVar}} {

--- a/internal/resources/cluster/constants.go
+++ b/internal/resources/cluster/constants.go
@@ -16,9 +16,10 @@ const (
 	attachClusterKubeConfigKey  = "kubeconfig_file"
 	attachClusterKey            = "attach_k8s_cluster"
 	attachClusterDescriptionKey = "description"
-	waitKey                     = "wait_until_ready"
+	waitKey                     = "ready_wait_timeout"
 	ResourceName                = "tmc_cluster"
 	tkgServiceVsphereKey        = "tkg_service_vsphere"
 	tkgVsphereClusterKey        = "tkg_vsphere"
 	proxyNameKey                = "proxy"
+	attachedValue               = "attached"
 )

--- a/internal/resources/namespace/data_source_namespace_test.go
+++ b/internal/resources/namespace/data_source_namespace_test.go
@@ -70,7 +70,7 @@ resource "%s" "%s" {
     cluster_group = "default"
   }
  
-  wait_until_ready = true
+  ready_wait_timeout = "3m"
 }
 
 resource "%s" "%s" {

--- a/internal/resources/namespace/resource_namepace_test.go
+++ b/internal/resources/namespace/resource_namepace_test.go
@@ -63,7 +63,7 @@ resource "%s" "%s" {
     cluster_group = "default"
   }
 
-  wait_until_ready = true
+  ready_wait_timeout = "3m"
 }
 
 resource "%s" "%s" {

--- a/resource_templates/tmc_cluster_attach.tf
+++ b/resource_templates/tmc_cluster_attach.tf
@@ -23,7 +23,7 @@ resource "tmc_cluster" "attach_cluster" {
     cluster_group = "<cluster-group>" // Default: default
   }
 
-  wait_until_ready = false // Default: false, when set resource waits until 3 min for the cluster to become ready
+  ready_wait_timeout = "15m" // Default: waits until 3 min for the cluster to become ready
 
   // The deployment link and the command needed to be run to attach this cluster would be provided in the output. status.execution_cmd
 }
@@ -49,9 +49,7 @@ resource "tmc_cluster" "attach_cluster_with_kubeconfig" {
     cluster_group = "<cluster-group>" // Default: default
   }
 
-  wait_until_ready = true // Default: false, when set resource waits until 3 min for the cluster to become ready
-
-  // The deployment link and the command needed to be run to attach this cluster would be provided in the output.status.execution_cmd
+   ready_wait_timeout = "3m" // Default: waits until 3 min for the cluster to become ready
 }
 
 // Create Tanzu Mission Control attach cluster entry with minimal information


### PR DESCRIPTION
Setting ready_wait_timeout value to a timeout duration will ensure that resource creation waits for cluster to reach READY state until the timeout duration is elapsed.

1. **What this PR does / why we need it**:

2. **Which issue(s) this PR fixes**

  Fixes #25


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->