### PR TITLE
Remove cloud and node labels in TKGm vSphere clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ vet:
 
 # Linter
 lint: gofmt
-	golangci-lint run -c ./.golangci.yml ./internal/... .
+	GO111MODULE=on golangci-lint run -c ./.golangci.yml ./internal/... .
 
 set-tf-acc:
 	@echo Setting Acceptance test env variable

--- a/internal/client/errors/errors.go
+++ b/internal/client/errors/errors.go
@@ -16,12 +16,6 @@ type ClientErrors struct {
 	err      error
 }
 
-func Error(err error) ClientErrors {
-	return ClientErrors{
-		err: err,
-	}
-}
-
 func ErrorWithHTTPCode(httpCode int, err error) ClientErrors {
 	return ClientErrors{
 		httpCode: httpCode,

--- a/internal/resources/cluster/config_test.go
+++ b/internal/resources/cluster/config_test.go
@@ -172,12 +172,6 @@ const testTKGmVsphereClusterScript = `
          	}
          	node_pools {
            		spec {
- 					cloud_label = {
- 						"key1": "val1"
- 					}
- 					node_label = {
- 						"key2": "val2"
- 					}
              		worker_node_count = "1"
              		tkg_vsphere {
  						vm_config {

--- a/internal/resources/cluster/helper_test.go
+++ b/internal/resources/cluster/helper_test.go
@@ -60,6 +60,7 @@ func withTKGsCluster() testAcceptanceOption {
 func withTKGmVsphereCluster() testAcceptanceOption {
 	return func(config *testAcceptanceConfig) {
 		config.ManagementClusterName = os.Getenv("MANAGEMENT_CLUSTER")
+		config.ProvisionerName = os.Getenv("PROVISIONER_NAME")
 		config.ControlPlaneEndPoint = os.Getenv("CONTROL_PLANE_ENDPOINT")
 		config.accTestType = tkgVsphereCluster
 		config.templateData = testTKGmVsphereClusterScript

--- a/internal/resources/cluster/resource_cluster_test.go
+++ b/internal/resources/cluster/resource_cluster_test.go
@@ -94,8 +94,8 @@ func testGetResourceClusterDefinition(t *testing.T, opts ...testAcceptanceOption
 		}
 
 	case tkgVsphereCluster:
-		if templateConfig.ManagementClusterName == "" || templateConfig.ControlPlaneEndPoint == "" {
-			t.Skip("MANAGEMENT CLUSTER or CONTROL PLANE ENDPOINT env var is not set for TKGm Vsphere acceptance test")
+		if templateConfig.ManagementClusterName == "" || templateConfig.ProvisionerName == "" || templateConfig.ControlPlaneEndPoint == "" {
+			t.Skip("MANAGEMENT CLUSTER, PROVISIONER or CONTROL PLANE ENDPOINT env var is not set for TKGm Vsphere acceptance test")
 		}
 	}
 

--- a/internal/resources/cluster/tkgvsphere/constants.go
+++ b/internal/resources/cluster/tkgvsphere/constants.go
@@ -35,8 +35,6 @@ const (
 	nodePoolSpecKey                  = "spec"
 	nodePoolDescriptionKey           = "description"
 	nodePoolNameKey                  = "name"
-	cloudLabelKey                    = "cloud_label"
-	nodeLabelKey                     = "node_label"
 	tkgVsphereKey                    = "tkg_vsphere"
 	workerNodeCountKey               = "worker_node_count"
 )

--- a/internal/resources/cluster/tkgvsphere/resource_tkgvsphere.go
+++ b/internal/resources/cluster/tkgvsphere/resource_tkgvsphere.go
@@ -11,7 +11,6 @@ import (
 
 	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 	tkgvspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 var TkgVsphereClusterSpec = &schema.Schema{
@@ -571,18 +570,6 @@ var tkgVsphereNodePoolSpec = &schema.Schema{
 				Description: "Count is the number of nodes",
 				Optional:    true,
 			},
-			nodeLabelKey: {
-				Type:        schema.TypeMap,
-				Description: "Node labels",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			cloudLabelKey: {
-				Type:        schema.TypeMap,
-				Description: "Cloud labels",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
 			tkgVsphereKey: {
 				Type:        schema.TypeList,
 				Description: "Nodepool config for tkgm vsphere",
@@ -613,16 +600,6 @@ func expandTKGVsphereTopologyNodePool(data interface{}) (nodePools *nodepoolmode
 
 			if v1, ok := spec[workerNodeCountKey]; ok {
 				nodePools.Spec.WorkerNodeCount, _ = v1.(string)
-			}
-
-			if v1, ok := spec[nodeLabelKey]; ok {
-				nodeLabels, _ := v1.(map[string]interface{})
-				nodePools.Spec.NodeLabels = common.GetTypeMapData(nodeLabels)
-			}
-
-			if v1, ok := spec[cloudLabelKey]; ok {
-				cloudLabels, _ := v1.(map[string]interface{})
-				nodePools.Spec.CloudLabels = common.GetTypeMapData(cloudLabels)
 			}
 
 			if v1, ok := spec[tkgVsphereKey]; ok {
@@ -672,8 +649,6 @@ func flattenTKGVsphereTopologyNodePool(nodePool *nodepoolmodel.VmwareTanzuManage
 		flattenNodePoolSpec := make(map[string]interface{})
 
 		flattenNodePoolSpec[workerNodeCountKey] = nodePool.Spec.WorkerNodeCount
-		flattenNodePoolSpec[nodeLabelKey] = nodePool.Spec.NodeLabels
-		flattenNodePoolSpec[cloudLabelKey] = nodePool.Spec.CloudLabels
 
 		if nodePool.Spec.TkgVsphere != nil {
 			flattenNodePoolSpec[tkgVsphereKey] = flattenNodePoolTKGVsphere(nodePool.Spec.TkgVsphere)

--- a/internal/resources/cluster/tkgvsphere/topology_flatten_test.go
+++ b/internal/resources/cluster/tkgvsphere/topology_flatten_test.go
@@ -67,8 +67,6 @@ func TestFlattenTopology(t *testing.T) {
 							Description: "testing topology flatten function",
 						},
 						Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
-							CloudLabels:     map[string]string{"cloud-key": "cloud-value"},
-							NodeLabels:      map[string]string{"node-key": "node-value"},
 							WorkerNodeCount: "1",
 							TkgVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGVsphereNodepool{
 								VMConfig: &nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGVsphereVMConfig{
@@ -94,8 +92,6 @@ func TestFlattenTopology(t *testing.T) {
 							},
 							nodePoolSpecKey: []interface{}{
 								map[string]interface{}{
-									cloudLabelKey:      map[string]string{"cloud-key": "cloud-value"},
-									nodeLabelKey:       map[string]string{"node-key": "node-value"},
 									workerNodeCountKey: "1",
 									tkgVsphereKey: []interface{}{
 										map[string]interface{}{
@@ -133,8 +129,6 @@ func TestFlattenTopology(t *testing.T) {
 							Description: "testing topology flatten function",
 						},
 						Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
-							CloudLabels:     map[string]string{"cloud-key": "cloud-value"},
-							NodeLabels:      map[string]string{"node-key": "node-value"},
 							WorkerNodeCount: "1",
 							TkgVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGVsphereNodepool{
 								VMConfig: &nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGVsphereVMConfig{
@@ -171,8 +165,6 @@ func TestFlattenTopology(t *testing.T) {
 							},
 							nodePoolSpecKey: []interface{}{
 								map[string]interface{}{
-									cloudLabelKey:      map[string]string{"cloud-key": "cloud-value"},
-									nodeLabelKey:       map[string]string{"node-key": "node-value"},
 									workerNodeCountKey: "1",
 									tkgVsphereKey: []interface{}{
 										map[string]interface{}{


### PR DESCRIPTION
1. **What this PR does / why we need it**: Remove cloud and node labels in TKGm vSphere

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #30


3. **Additional information**

Node and Cloud labels and not supported for TKGm vSphere workload clusters and some minor test fixes

4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->