### PR TITLE
Update tanzu-mission-control_cluster.md

### DIFF
--- a/docs/guides/tanzu-mission-control_cluster.md
+++ b/docs/guides/tanzu-mission-control_cluster.md
@@ -228,13 +228,7 @@ resource "tanzu-mission-control_cluster" "create_tkg_vsphere_cluster" {
         node_pools {
           spec {
             worker_node_count = "<worker-node-count>" // Required
-            cloud_label = {
-              "<key>" : "<val>"
-            }
-            node_label = {
-              "<key>" : "<val>"
-            }
-
+          
             tkg_vsphere {
               vm_config {
                 cpu       = "<cpu>"       // Required


### PR DESCRIPTION
Removed `node_label` and `cloud_label`. These labels are removed since 1.0.2.

1. **What this PR does / why we need it**:
   Removed `node_label` and `cloud_label`. These labels are removed since 1.0.2.
