### PR TITLE
Handle manual delete of tf resources gracefully

### DIFF
--- a/internal/resources/clustergroup/data_source_cluster_group.go
+++ b/internal/resources/clustergroup/data_source_cluster_group.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
 	clustergroupmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
 	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
@@ -38,6 +39,11 @@ func dataSourceClusterGroupRead(_ context.Context, d *schema.ResourceData, m int
 
 	resp, err := config.TMCConnection.ClusterGroupResourceService.ManageV1alpha1ClusterGroupResourceServiceGet(fn)
 	if err != nil {
+		if clienterrors.IsNotFoundError(err) {
+			d.SetId("")
+			return
+		}
+
 		return diag.FromErr(errors.Wrapf(err, "Unable to get Tanzu Mission Control cluster group entry, name : %s", clusterGroupName))
 	}
 

--- a/internal/resources/namespace/data_source_namespace.go
+++ b/internal/resources/namespace/data_source_namespace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
 	namespacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/namespace"
 	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
@@ -37,6 +38,11 @@ func dataSourceNamespaceRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	resp, err = config.TMCConnection.NamespaceResourceService.ManageV1alpha1NamespaceResourceServiceGet(constructFullname(d))
 	if err != nil || resp == nil {
+		if clienterrors.IsNotFoundError(err) {
+			d.SetId("")
+			return diags
+		}
+
 		return diag.FromErr(errors.Wrapf(err, "unable to get Tanzu Mission Control namespace entry, name : %s", namespaceName))
 	}
 

--- a/internal/resources/workspace/data_source_workspace.go
+++ b/internal/resources/workspace/data_source_workspace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
 	workspacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/workspace"
 	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
@@ -38,6 +39,11 @@ func dataSourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	resp, err := config.TMCConnection.WorkspaceResourceService.ManageV1alpha1WorkspaceResourceServiceGet(fn)
 	if err != nil {
+		if clienterrors.IsNotFoundError(err) {
+			d.SetId("")
+			return
+		}
+
 		return diag.FromErr(errors.Wrapf(err, "Unable to get Tanzu Mission Control workspace entry, name : %s", workspaceName))
 	}
 


### PR DESCRIPTION


1. **What this PR does / why we need it**:
2. 
When you create something in Terraform but delete it manually, Terraform
should gracefully handle it. If the API returns an error when the resource
doesn't exist, the read function should check to see if the resource is available
first. If the resource isn't available, the function should set the ID to an empty
string so Terraform "destroys" the resource in state

3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->