### PR TITLE
add request URL builder helper for cluster resource service client

### DIFF
--- a/internal/client/cluster/cluster_resource.go
+++ b/internal/client/cluster/cluster_resource.go
@@ -6,11 +6,18 @@ SPDX-License-Identifier: MPL-2.0
 package clusterclient
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/transport"
+	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
 	clustermodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster"
+)
+
+const (
+	apiVersionAndGroup                 = "v1alpha1/clusters"
+	queryParamKeyForce                 = "force"
+	queryParamKeyManagementClusterName = "fullName.managementClusterName"
+	queryParamKeyProvisionerName       = "fullName.provisionerName"
 )
 
 // New creates a new cluster resource service API client.
@@ -43,7 +50,7 @@ func (c *Client) ManageV1alpha1ClusterResourceServiceCreate(
 	request *clustermodel.VmwareTanzuManageV1alpha1ClusterRequest,
 ) (*clustermodel.VmwareTanzuManageV1alpha1ClusterResponse, error) {
 	response := &clustermodel.VmwareTanzuManageV1alpha1ClusterResponse{}
-	err := c.Create("v1alpha1/clusters", request, response)
+	err := c.Create(apiVersionAndGroup, request, response)
 
 	return response, err
 }
@@ -55,7 +62,7 @@ func (c *Client) ManageV1alpha1ClusterResourceServiceUpdate(
 	request *clustermodel.VmwareTanzuManageV1alpha1ClusterRequest,
 ) (*clustermodel.VmwareTanzuManageV1alpha1ClusterResponse, error) {
 	response := &clustermodel.VmwareTanzuManageV1alpha1ClusterResponse{}
-	requestURL := fmt.Sprintf("%s/%s", "v1alpha1/clusters", request.Cluster.FullName.Name)
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup, request.Cluster.FullName.Name).String()
 	err := c.Update(requestURL, request, response)
 
 	return response, err
@@ -68,18 +75,18 @@ func (c *Client) ManageV1alpha1ClusterResourceServiceDelete(
 	fn *clustermodel.VmwareTanzuManageV1alpha1ClusterFullName, force string,
 ) error {
 	queryParams := url.Values{
-		"force": []string{force},
+		queryParamKeyForce: []string{force},
 	}
 
 	if fn.ManagementClusterName != "" {
-		queryParams["fullName.managementClusterName"] = []string{fn.ManagementClusterName}
+		queryParams.Add(queryParamKeyManagementClusterName, fn.ManagementClusterName)
 	}
 
 	if fn.ProvisionerName != "" {
-		queryParams["fullName.provisionerName"] = []string{fn.ProvisionerName}
+		queryParams.Add(queryParamKeyProvisionerName, fn.ProvisionerName)
 	}
 
-	requestURL := fmt.Sprintf("%s/%s?%s", "v1alpha1/clusters", fn.Name, queryParams.Encode())
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup, fn.Name).AppendQueryParams(queryParams).String()
 
 	return c.Delete(requestURL)
 }
@@ -93,14 +100,14 @@ func (c *Client) ManageV1alpha1ClusterResourceServiceGet(
 	queryParams := url.Values{}
 
 	if fn.ManagementClusterName != "" {
-		queryParams["fullName.managementClusterName"] = []string{fn.ManagementClusterName}
+		queryParams.Add(queryParamKeyManagementClusterName, fn.ManagementClusterName)
 	}
 
 	if fn.ProvisionerName != "" {
-		queryParams["fullName.provisionerName"] = []string{fn.ProvisionerName}
+		queryParams.Add(queryParamKeyProvisionerName, fn.ProvisionerName)
 	}
 
-	requestURL := fmt.Sprintf("%s/%s?%s", "v1alpha1/clusters", fn.Name, queryParams.Encode())
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup, fn.Name).AppendQueryParams(queryParams).String()
 	clusterResponse := &clustermodel.VmwareTanzuManageV1alpha1ClusterGetClusterResponse{}
 	err := c.Get(requestURL, clusterResponse)
 

--- a/internal/helper/request_url.go
+++ b/internal/helper/request_url.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package helper
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type RequestURL string
+
+// ConstructRequestURL constructs a request URL based on paths.
+func ConstructRequestURL(paths ...string) (url RequestURL) {
+	if len(paths) == 0 || paths[0] == "" {
+		return url
+	}
+
+	url = RequestURL(paths[0])
+
+	for _, value := range paths[1:] {
+		url = RequestURL(fmt.Sprintf("%s/%s", url, value))
+	}
+
+	return url
+}
+
+// AppendQueryParams appends query parameters to a request URL.
+func (ru RequestURL) AppendQueryParams(queryParameters url.Values) (url RequestURL) {
+	if queryParameters == nil || len(queryParameters) == 0 {
+		return ru
+	}
+
+	url = RequestURL(fmt.Sprintf("%s?%s", ru, queryParameters.Encode()))
+
+	return url
+}
+
+// String converts a request URL to a string.
+func (ru RequestURL) String() (urlString string) {
+	return string(ru)
+}

--- a/internal/helper/request_url_test.go
+++ b/internal/helper/request_url_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package helper
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstructRequestURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		paths    []string
+		expected RequestURL
+	}{
+		{
+			name:     "case for no paths",
+			paths:    []string{},
+			expected: "",
+		},
+		{
+			name:     "case for a single path",
+			paths:    []string{"p1"},
+			expected: "p1",
+		},
+		{
+			name:     "case for multiple successive paths",
+			paths:    []string{"p1", "p2", "p3"},
+			expected: "p1/p2/p3",
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.name, func(t *testing.T) {
+			actual := ConstructRequestURL(test.paths...)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestAppendQueryParams(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		requestURL      RequestURL
+		queryParameters url.Values
+		expected        RequestURL
+	}{
+		{
+			name:            "case for no query parameter",
+			requestURL:      "p1",
+			queryParameters: nil,
+			expected:        "p1",
+		},
+		{
+			name:       "case for one query parameter",
+			requestURL: "p1",
+			queryParameters: url.Values{
+				"k1": []string{"v1"},
+			},
+			expected: "p1?k1=v1",
+		},
+		{
+			name:       "case for multiple query parameters",
+			requestURL: "p1/p2/p3",
+			queryParameters: url.Values{
+				"k1": []string{"v1"},
+				"k2": []string{"v2"},
+			},
+			expected: "p1/p2/p3?k1=v1&k2=v2",
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.requestURL.AppendQueryParams(test.queryParameters)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		requestURL RequestURL
+		expected   string
+	}{
+		{
+			name:       "case for empty path",
+			requestURL: "",
+			expected:   "",
+		},
+		{
+			name:       "case for multiple paths and query parameters",
+			requestURL: "p1/p2/p3?k1=v1&k2=v2",
+			expected:   "p1/p2/p3?k1=v1&k2=v2",
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.requestURL.String()
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ishan Gupta <gishan@vmware.com>

**What this PR does / why we need it**: add request URL builder helper for cluster resource service client

Changes introduced as per: https://github.com/vmware/terraform-provider-tanzu-mission-control/pull/50#discussion_r935436381