### PR TITLE
Change project module path from "github.com/vmware-tanzu" to "github.…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,7 @@ linters-settings:
   gocognit:
     min-complexity: 60
   goimports:
-    local-prefixes: github.com/vmware-tanzu/terraform-provider-tanzu-mission-control
+    local-prefixes: github.com/vmware/terraform-provider-tanzu-mission-control
 
 issues:
   exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ build:
 	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_amd64/
 	cp bin/terraform-provider-tanzu-mission-control_v1.0.0 ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_amd64/
 
+build-arm:
+	go build -o bin/terraform-provider-tanzu-mission-control_v1.0.0
+	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_arm64/
+	cp bin/terraform-provider-tanzu-mission-control_v1.0.0 ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_arm64/
+
 test: | gofmt vet lint
 	go mod tidy
 	go test ./internal/... -cover

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ For developing, consider using [dev overrides configuration][dev-overrides]. Ple
 work is not being duplicated. For further clarification, you can also ask in a
 new issue.
 
-[gh-issues]: https://github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/issues
-[gh-prs]: https://github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/pulls
+[gh-issues]: https://github.com/vmware/terraform-provider-tanzu-mission-control/issues
+[gh-prs]: https://github.com/vmware/terraform-provider-tanzu-mission-control/pulls
 
 If you wish to work on the provider, you'll first need [Go][go-website]
 installed on your machine (version 1.14+ is recommended). You'll also need to
@@ -170,4 +170,4 @@ The Tanzu Mission Control Terraform provider is now VMware supported as well as 
 
 Copyright © 2015-2022 VMware, Inc. All Rights Reserved.
 
-The Tanzu Mission Control Terraform provider is available under [MPL2.0 license](https://github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/blob/main/LICENSE).
+The Tanzu Mission Control Terraform provider is available under [MPL2.0 license](https://github.com/vmware/terraform-provider-tanzu-mission-control/blob/main/LICENSE).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/terraform-provider-tanzu-mission-control
+module github.com/vmware/terraform-provider-tanzu-mission-control
 
 go 1.18
 

--- a/internal/authctx/client.go
+++ b/internal/authctx/client.go
@@ -8,7 +8,7 @@ package authctx
 import (
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client"
 )
 
 const (

--- a/internal/client/cluster/cluster_resource.go
+++ b/internal/client/cluster/cluster_resource.go
@@ -8,9 +8,9 @@ package clusterclient
 import (
 	"net/url"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/transport"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
-	clustermodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
 )
 
 const (

--- a/internal/client/clustergroup/cluster_group_resource.go
+++ b/internal/client/clustergroup/cluster_group_resource.go
@@ -8,8 +8,8 @@ package clustergroupclient
 import (
 	"fmt"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/transport"
-	clustergroupmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
+	clustergroupmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
 )
 
 // New creates a new cluster group resource service API client.

--- a/internal/client/http_client.go
+++ b/internal/client/http_client.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"runtime"
 
-	clusterclient "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/cluster"
-	clustergroupclient "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/clustergroup"
-	namespaceclient "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/namespace"
-	nodepoolclient "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/nodepool"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/transport"
-	workspaceclient "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/workspace"
+	clusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster"
+	clustergroupclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/clustergroup"
+	namespaceclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/namespace"
+	nodepoolclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/nodepool"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
+	workspaceclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/workspace"
 )
 
 // NewHTTPClient creates a new  tanzu mission control HTTP client.

--- a/internal/client/namespace/namespace_resource.go
+++ b/internal/client/namespace/namespace_resource.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/transport"
-	namespacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/namespace"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
+	namespacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/namespace"
 )
 
 // New creates a new namespace resource service API client.

--- a/internal/client/nodepool/nodepool_resource.go
+++ b/internal/client/nodepool/nodepool_resource.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/transport"
-	nodepoolsmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
+	nodepoolsmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 )
 
 // New creates a new cluster node pool resource service API client.

--- a/internal/client/transport/methods.go
+++ b/internal/client/transport/methods.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
 )
 
 type Request interface {

--- a/internal/client/transport/methods_test.go
+++ b/internal/client/transport/methods_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	workspacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/workspace"
+	workspacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/workspace"
 )
 
 type Invoke struct {

--- a/internal/client/workspace/workspace_resource.go
+++ b/internal/client/workspace/workspace_resource.go
@@ -8,8 +8,8 @@ package workspaceclient
 import (
 	"fmt"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/transport"
-	workspacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/workspace"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
+	workspacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/workspace"
 )
 
 // New creates a new workspace resource service API client.

--- a/internal/models/cluster/cluster.go
+++ b/internal/models/cluster/cluster.go
@@ -8,7 +8,7 @@ package clustermodel
 import (
 	"github.com/go-openapi/swag"
 
-	objectmetamodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
 )
 
 // VmwareTanzuManageV1alpha1ClusterCluster A Kubernetes Cluster.

--- a/internal/models/cluster/nodepool/nodepools.go
+++ b/internal/models/cluster/nodepool/nodepools.go
@@ -8,7 +8,7 @@ package nodepool
 import (
 	"github.com/go-openapi/swag"
 
-	objectmetamodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
 )
 
 // VmwareTanzuManageV1alpha1ClusterNodepoolDefinition Definition is the definition of nodepool for cluster

--- a/internal/models/cluster/spec.go
+++ b/internal/models/cluster/spec.go
@@ -8,9 +8,9 @@ package clustermodel
 import (
 	"github.com/go-openapi/swag"
 
-	tkgawsmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
-	tkgservicevspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
-	tkgvspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
+	tkgawsmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
+	tkgservicevspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
+	tkgvspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
 )
 
 // VmwareTanzuManageV1alpha1ClusterSpec Spec of the cluster.

--- a/internal/models/cluster/tkgaws/tkgaws_topology.go
+++ b/internal/models/cluster/tkgaws/tkgaws_topology.go
@@ -8,7 +8,7 @@ package tkgawsmodel
 import (
 	"github.com/go-openapi/swag"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 )
 
 // VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsTopology Topology is the topology definition for the cluster.

--- a/internal/models/cluster/tkgservicevsphere/tkgs_controlplane.go
+++ b/internal/models/cluster/tkgservicevsphere/tkgs_controlplane.go
@@ -8,7 +8,7 @@ package tkgservicevspheremodel
 import (
 	"github.com/go-openapi/swag"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 )
 
 // VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereControlPlane VSphere specific control plane configuration for workload cluster object.

--- a/internal/models/cluster/tkgservicevsphere/tkgs_topology.go
+++ b/internal/models/cluster/tkgservicevsphere/tkgs_topology.go
@@ -8,7 +8,7 @@ package tkgservicevspheremodel
 import (
 	"github.com/go-openapi/swag"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 )
 
 // VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereTopology Topology is the topology for tkg service vsphere cluster.

--- a/internal/models/cluster/tkgvsphere/tkgvsphere_control_plane.go
+++ b/internal/models/cluster/tkgvsphere/tkgvsphere_control_plane.go
@@ -8,7 +8,7 @@ package tkgvspheremodel
 import (
 	"github.com/go-openapi/swag"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 )
 
 // VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereControlPlane VSphere specific control plane configuration for workload cluster object.

--- a/internal/models/cluster/tkgvsphere/tkgvsphere_topology.go
+++ b/internal/models/cluster/tkgvsphere/tkgvsphere_topology.go
@@ -8,7 +8,7 @@ package tkgvspheremodel
 import (
 	"github.com/go-openapi/swag"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 )
 
 // VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereTopology Topology specific configuration.

--- a/internal/models/clustergroup/cluster_group.go
+++ b/internal/models/clustergroup/cluster_group.go
@@ -8,7 +8,7 @@ package clustergroupmodel
 import (
 	"github.com/go-openapi/swag"
 
-	objectmetamodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
 )
 
 // VmwareTanzuManageV1alpha1ClustergroupClusterGroup A group of Kubernetes clusters.

--- a/internal/models/namespace/namespace.go
+++ b/internal/models/namespace/namespace.go
@@ -8,7 +8,7 @@ package namespacemodel
 import (
 	"github.com/go-openapi/swag"
 
-	objectmetamodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
 )
 
 // VmwareTanzuManageV1alpha1ClusterNamespaceNamespace A managed Kubernetes namespace.

--- a/internal/models/workspace/workspace.go
+++ b/internal/models/workspace/workspace.go
@@ -8,7 +8,7 @@ package workspacemodel
 import (
 	"github.com/go-openapi/swag"
 
-	objectmetamodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
 )
 
 // VmwareTanzuManageV1alpha1WorkspaceWorkspace A group of managed Kubenetes namespaces.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,12 +8,12 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/cluster"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/cluster/nodepools"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/clustergroup"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/namespace"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/workspace"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/nodepools"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/clustergroup"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/namespace"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/workspace"
 )
 
 // Provider for Tanzu Mission Control resources.

--- a/internal/resources/cluster/cluster_flatten_test.go
+++ b/internal/resources/cluster/cluster_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clustermodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
 )
 
 func TestFlattenSpec(t *testing.T) {

--- a/internal/resources/cluster/cluster_provider_test.go
+++ b/internal/resources/cluster/cluster_provider_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
 )
 
 func initTestProvider(t *testing.T) *schema.Provider {

--- a/internal/resources/cluster/data_source_cluster.go
+++ b/internal/resources/cluster/data_source_cluster.go
@@ -15,11 +15,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
-	clustermodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 func DataSourceTMCCluster() *schema.Resource {

--- a/internal/resources/cluster/data_source_cluster_test.go
+++ b/internal/resources/cluster/data_source_cluster_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 func TestAcceptanceForAttachClusterDataSource(t *testing.T) {

--- a/internal/resources/cluster/helper_test.go
+++ b/internal/resources/cluster/helper_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"text/template"
 
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 type acceptanceTestType int

--- a/internal/resources/cluster/manifest/helper.go
+++ b/internal/resources/cluster/manifest/helper.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
 )
 
 type manifest struct {

--- a/internal/resources/cluster/nodepools/data_source_node_pool.go
+++ b/internal/resources/cluster/nodepools/data_source_node_pool.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	nodepoolsmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	nodepoolsmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 func DataSourceClusterNodePool() *schema.Resource {

--- a/internal/resources/cluster/nodepools/resource_node_pool.go
+++ b/internal/resources/cluster/nodepools/resource_node_pool.go
@@ -13,11 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 const (

--- a/internal/resources/cluster/nodepools/spec_flatten_test.go
+++ b/internal/resources/cluster/nodepools/spec_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
 )
 
 func TestFlattenNodePoolSpec(t *testing.T) {

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -16,15 +16,15 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
-	clustermodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/cluster/manifest"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/cluster/tkgaws"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/cluster/tkgservicevsphere"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/cluster/tkgvsphere"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/manifest"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/tkgaws"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/tkgservicevsphere"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/tkgvsphere"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 type (

--- a/internal/resources/cluster/resource_cluster_test.go
+++ b/internal/resources/cluster/resource_cluster_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
-	clustermodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster"
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 const (

--- a/internal/resources/cluster/tkgaws/distribution_flatten_test.go
+++ b/internal/resources/cluster/tkgaws/distribution_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	tkgawsmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
+	tkgawsmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
 )
 
 func TestFlattenDistribution(t *testing.T) {

--- a/internal/resources/cluster/tkgaws/resource_tkg_aws.go
+++ b/internal/resources/cluster/tkgaws/resource_tkg_aws.go
@@ -8,8 +8,8 @@ package tkgaws
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
-	tkgawsmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	tkgawsmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
 )
 
 var TkgAWSClusterSpec = &schema.Schema{

--- a/internal/resources/cluster/tkgaws/settings_flatten_test.go
+++ b/internal/resources/cluster/tkgaws/settings_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	tkgawsmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
+	tkgawsmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
 )
 
 func TestFlattenSettings(t *testing.T) {

--- a/internal/resources/cluster/tkgaws/topology_flatten_test.go
+++ b/internal/resources/cluster/tkgaws/topology_flatten_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
-	tkgawsmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	tkgawsmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
 )
 
 func TestFlattenTopology(t *testing.T) {

--- a/internal/resources/cluster/tkgservicevsphere/distribution_flatten_test.go
+++ b/internal/resources/cluster/tkgservicevsphere/distribution_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	tkgservicevspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
+	tkgservicevspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
 )
 
 func TestFlattenDistribution(t *testing.T) {

--- a/internal/resources/cluster/tkgservicevsphere/resource_tkg_service_vsphere.go
+++ b/internal/resources/cluster/tkgservicevsphere/resource_tkg_service_vsphere.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
-	tkgservicevspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	tkgservicevspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 var TkgServiceVsphere = &schema.Schema{

--- a/internal/resources/cluster/tkgservicevsphere/settings_flatten_test.go
+++ b/internal/resources/cluster/tkgservicevsphere/settings_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	tkgservicevspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
+	tkgservicevspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
 )
 
 func TestFlattenSettings(t *testing.T) {

--- a/internal/resources/cluster/tkgservicevsphere/topology_flatten_test.go
+++ b/internal/resources/cluster/tkgservicevsphere/topology_flatten_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
-	tkgservicevspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	tkgservicevspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
 )
 
 func TestFlattenTopology(t *testing.T) {

--- a/internal/resources/cluster/tkgvsphere/distribution_flatten_test.go
+++ b/internal/resources/cluster/tkgvsphere/distribution_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	tkgvspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
+	tkgvspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
 )
 
 func TestFlattenDistribution(t *testing.T) {

--- a/internal/resources/cluster/tkgvsphere/resource_tkgvsphere.go
+++ b/internal/resources/cluster/tkgvsphere/resource_tkgvsphere.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
-	tkgvspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	tkgvspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
 )
 
 var TkgVsphereClusterSpec = &schema.Schema{

--- a/internal/resources/cluster/tkgvsphere/settings_flatten_test.go
+++ b/internal/resources/cluster/tkgvsphere/settings_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	tkgvspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
+	tkgvspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
 )
 
 func TestFlattenSettings(t *testing.T) {

--- a/internal/resources/cluster/tkgvsphere/topology_flatten_test.go
+++ b/internal/resources/cluster/tkgvsphere/topology_flatten_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	nodepoolmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
-	tkgvspheremodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	tkgvspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
 )
 
 func TestFlattenTopology(t *testing.T) {

--- a/internal/resources/clustergroup/clustergroup_provider_test.go
+++ b/internal/resources/clustergroup/clustergroup_provider_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
 )
 
 func initTestProvider(t *testing.T) *schema.Provider {

--- a/internal/resources/clustergroup/data_source_cluster_group.go
+++ b/internal/resources/clustergroup/data_source_cluster_group.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	clustergroupmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	clustergroupmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 func DataSourceClusterGroup() *schema.Resource {

--- a/internal/resources/clustergroup/data_source_cluster_group_test.go
+++ b/internal/resources/clustergroup/data_source_cluster_group_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 const (

--- a/internal/resources/clustergroup/resource_cluster_group.go
+++ b/internal/resources/clustergroup/resource_cluster_group.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	clustergroupmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	clustergroupmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 const (

--- a/internal/resources/clustergroup/resource_cluster_group_test.go
+++ b/internal/resources/clustergroup/resource_cluster_group_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clustergroupmodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clustergroupmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/clustergroup"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 func TestAcceptanceForClusterGroupResource(t *testing.T) {

--- a/internal/resources/common/meta_flatten_test.go
+++ b/internal/resources/common/meta_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	objectmetamodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
 )
 
 func TestFlattenMeta(t *testing.T) {

--- a/internal/resources/common/objectmeta_schema.go
+++ b/internal/resources/common/objectmeta_schema.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
-	objectmetamodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
 )
 
 const (

--- a/internal/resources/namespace/data_source_namespace.go
+++ b/internal/resources/namespace/data_source_namespace.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	namespacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/namespace"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	namespacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/namespace"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 func DataSourceNamespace() *schema.Resource {

--- a/internal/resources/namespace/data_source_namespace_test.go
+++ b/internal/resources/namespace/data_source_namespace_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 const (

--- a/internal/resources/namespace/namespace_flatten_test.go
+++ b/internal/resources/namespace/namespace_flatten_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	namespacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/namespace"
+	namespacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/namespace"
 )
 
 func TestFlattenSpec(t *testing.T) {

--- a/internal/resources/namespace/namespace_provider_test.go
+++ b/internal/resources/namespace/namespace_provider_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/cluster"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster"
 )
 
 const providerName = "tmc"

--- a/internal/resources/namespace/resource_namepace_test.go
+++ b/internal/resources/namespace/resource_namepace_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	namespacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/namespace"
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	namespacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/namespace"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 func TestAcceptanceForNamespaceResource(t *testing.T) {

--- a/internal/resources/namespace/resource_namespace.go
+++ b/internal/resources/namespace/resource_namespace.go
@@ -12,11 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/helper"
-	namespacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/namespace"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	namespacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/namespace"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 func ResourceNamespace() *schema.Resource {

--- a/internal/resources/testing/provider.go
+++ b/internal/resources/testing/provider.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
 )
 
 func TestPreCheck(t *testing.T) func() {

--- a/internal/resources/workspace/data_source_workspace.go
+++ b/internal/resources/workspace/data_source_workspace.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	workspacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/workspace"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	workspacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/workspace"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 func DataSourceWorkspace() *schema.Resource {

--- a/internal/resources/workspace/data_source_workspace_test.go
+++ b/internal/resources/workspace/data_source_workspace_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 const (

--- a/internal/resources/workspace/resource_workspace.go
+++ b/internal/resources/workspace/resource_workspace.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	clienterrors "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/client/errors"
-	workspacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/workspace"
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	workspacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/workspace"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
 
 const (

--- a/internal/resources/workspace/resource_workspace_test.go
+++ b/internal/resources/workspace/resource_workspace_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
-	workspacemodel "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/models/workspace"
-	testhelper "github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/resources/testing"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	workspacemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/workspace"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
 
 func TestAcceptanceForWorkspaceResource(t *testing.T) {

--- a/internal/resources/workspace/workspace_provider_test.go
+++ b/internal/resources/workspace/workspace_provider_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
 )
 
 func initTestProvider(t *testing.T) *schema.Provider {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/vmware-tanzu/terraform-provider-tanzu-mission-control/internal/provider"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/provider"
 )
 
 func main() {


### PR DESCRIPTION
…com/vmware"

Initially the projected was created github.com/vmware-tanzu organisation and later it was moved under github.com/vmware but the module path was not migrated.

1. **What this PR does / why we need it**:

Change project module path

3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->