### PR TITLE
acceptance tests for security policy resource with minor fix

### DIFF
--- a/internal/resources/common/objectmeta_schema.go
+++ b/internal/resources/common/objectmeta_schema.go
@@ -111,11 +111,15 @@ func ConstructMeta(d *schema.ResourceData) (objectMeta *objectmetamodel.VmwareTa
 	}
 
 	if v, ok := objectMetaData[DescriptionKey]; ok {
-		objectMeta.Description = v.(string)
+		helper.SetPrimitiveValue(v, &objectMeta.Description, DescriptionKey)
 	}
 
 	if v, ok := objectMetaData[uidKey]; ok {
-		objectMeta.UID = v.(string)
+		helper.SetPrimitiveValue(v, &objectMeta.UID, uidKey)
+	}
+
+	if v, ok := objectMetaData[resourceVersionKey]; ok {
+		helper.SetPrimitiveValue(v, &objectMeta.ResourceVersion, resourceVersionKey)
 	}
 
 	return objectMeta
@@ -132,6 +136,7 @@ func FlattenMeta(objectMeta *objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta) 
 	flattenMetaData[LabelsKey] = objectMeta.Labels
 	flattenMetaData[DescriptionKey] = objectMeta.Description
 	flattenMetaData[uidKey] = objectMeta.UID
+	flattenMetaData[resourceVersionKey] = objectMeta.ResourceVersion
 
 	return []interface{}{flattenMetaData}
 }

--- a/internal/resources/policy/test_helper.go
+++ b/internal/resources/policy/test_helper.go
@@ -1,0 +1,16 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package policy
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+func MetaResourceAttributeCheck(resourceName string) []resource.TestCheckFunc {
+	return []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "meta.#", "1"),
+		resource.TestCheckResourceAttrSet(resourceName, "meta.0.uid"),
+		resource.TestCheckResourceAttrSet(resourceName, "meta.0.resource_version"),
+	}
+}

--- a/internal/resources/policy/type/security/constants.go
+++ b/internal/resources/policy/type/security/constants.go
@@ -22,13 +22,15 @@ const (
 
 // Allowed scopes.
 const (
-	clusterScope scope = iota
+	unknownScope scope = iota
+	clusterScope
 	clusterGroupScope
 	organizationScope
 )
 
 // Allowed input recipes.
 const (
+	unknownRecipe  recipe = ""
 	baselineRecipe recipe = reciperesource.BaselineKey
 	customRecipe   recipe = reciperesource.CustomKey
 	strictRecipe   recipe = reciperesource.StrictKey

--- a/internal/resources/policy/type/security/resource_security_policy.go
+++ b/internal/resources/policy/type/security/resource_security_policy.go
@@ -8,6 +8,7 @@ package security
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -113,6 +114,8 @@ func resourceSecurityPolicyCreate(ctx context.Context, d *schema.ResourceData, m
 
 				UID = securityPolicyResponse.Policy.Meta.UID
 			}
+		case unknownScope:
+			log.Fatalf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scopesAllowed[:], `, `))
 		}
 
 		// always run
@@ -235,6 +238,8 @@ func resourceSecurityPolicyRead(ctx context.Context, d *schema.ResourceData, m i
 				meta = resp.Policy.Meta
 				spec = resp.Policy.Spec
 			}
+		case unknownScope:
+			log.Fatalf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scopesAllowed[:], `, `))
 		}
 
 		// always run
@@ -306,6 +311,8 @@ func resourceSecurityPolicyInPlaceUpdate(ctx context.Context, d *schema.Resource
 				meta = getResp.Policy.Meta
 				spec = getResp.Policy.Spec
 			}
+		case unknownScope:
+			log.Fatalf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scopesAllowed[:], `, `))
 		}
 
 		if updateCheckForMeta(d, meta) {
@@ -363,6 +370,8 @@ func resourceSecurityPolicyInPlaceUpdate(ctx context.Context, d *schema.Resource
 						return diag.FromErr(errors.Wrapf(err, "Unable to update Tanzu Mission Control organization security policy entry, name : %s", securityPolicyName))
 					}
 				}
+			case unknownScope:
+				log.Fatalf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scopesAllowed[:], `, `))
 			}
 
 			log.Printf("[INFO] security policy update successful")
@@ -438,6 +447,8 @@ func resourceSecurityPolicyDelete(ctx context.Context, d *schema.ResourceData, m
 					return diag.FromErr(errors.Wrapf(err, "Unable to delete Tanzu Mission Control organization security policy entry, name : %s", securityPolicyName))
 				}
 			}
+		case unknownScope:
+			log.Fatalf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scopesAllowed[:], `, `))
 		}
 	}
 

--- a/internal/resources/policy/type/security/security_policy_provider_test.go
+++ b/internal/resources/policy/type/security/security_policy_provider_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package security
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/clustergroup"
+)
+
+func initTestProvider(t *testing.T) *schema.Provider {
+	testAccProvider := &schema.Provider{
+		Schema: authctx.ProviderAuthSchema(),
+		ResourcesMap: map[string]*schema.Resource{
+			ResourceName:              ResourceSecurityPolicy(),
+			cluster.ResourceName:      cluster.ResourceTMCCluster(),
+			clustergroup.ResourceName: clustergroup.ResourceClusterGroup(),
+		},
+		ConfigureContextFunc: authctx.ProviderConfigureContext,
+	}
+	if err := testAccProvider.InternalValidate(); err != nil {
+		require.NoError(t, err)
+	}
+
+	return testAccProvider
+}

--- a/internal/resources/policy/type/security/spec_schema.go
+++ b/internal/resources/policy/type/security/spec_schema.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -70,6 +71,8 @@ func constructSpec(d *schema.ResourceData) (spec *policymodel.VmwareTanzuManageV
 					if inputRecipeData.inputStrict != nil {
 						spec.Input = *inputRecipeData.inputStrict
 					}
+				case unknownRecipe:
+					log.Fatalf("[ERROR]: No valid input recipe block found: minimum one valid input recipe block is required among: %v. Please check the schema.", strings.Join(recipesAllowed[:], `, `))
 				}
 			}
 		}
@@ -137,6 +140,8 @@ func flattenSpec(spec *policymodel.VmwareTanzuManageV1alpha1CommonPolicySpec) (d
 					recipe:      strictRecipe,
 					inputStrict: &strictRecipeInput,
 				}
+			case string(unknownRecipe):
+				log.Fatalf("[ERROR]: No valid input recipe block found: minimum one valid input recipe block is required among: %v. Please check the schema.", strings.Join(recipesAllowed[:], `, `))
 			}
 
 			flattenSpecData[inputKey] = flattenInput(inputRecipeData)


### PR DESCRIPTION
1. **What this PR does / why we need it**:  This PR [adds acceptance tests for security policy resource](https://github.com/vmware/terraform-provider-tanzu-mission-control/pull/56/commits/70f0b630cc49b9d466ffec3356302111d9246fa6) with a minor fix: [add unknown type for scope and recipe in security policy resource](https://github.com/vmware/terraform-provider-tanzu-mission-control/pull/56/commits/a986f7addb4ca9f20223171b44cf732bdea854ae)

2. **Additional information**: Tested for all cases.

3. **Screenshot of test results**:

<img width="1753" alt="Screenshot 2022-08-11 at 3 05 42 PM" src="https://user-images.githubusercontent.com/50652677/184106426-e97b2d68-8325-4a9e-8df4-6908492947c5.png">

