### PR TITLE
Update vmware csp client used to fetch refresh token

### DIFF
--- a/internal/authctx/authentication.go
+++ b/internal/authctx/authentication.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -49,16 +50,17 @@ func getBearerToken(cspEndpoint, cspToken string) (string, error) {
 		err  error
 	)
 
+	data := url.Values{}
+	data.Set("refresh_token", cspToken)
+	encodedToken := strings.NewReader(data.Encode())
+
 	for i := 0; i < 10; i++ {
 		resp, err = client.Post(
-			fmt.Sprintf(
-				"https://%s/csp/gateway/am/api/auth/api-tokens/authorize?refresh_token=%s",
-				cspEndpoint,
-				cspToken,
-			),
-			"application/json",
-			nil,
+			fmt.Sprintf("https://%s/csp/gateway/am/api/auth/api-tokens/authorize", cspEndpoint),
+			"application/x-www-form-urlencoded",
+			encodedToken,
 		)
+
 		if err == nil {
 			defer resp.Body.Close()
 			break


### PR DESCRIPTION

1. **What this PR does / why we need it**:

Update vmware csp client used to fetch refresh token.
Move from query param to form-encoded value when passing CSP_TOKEN to fetch refresh_token


3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**

The support for fetching refresh tokens using query-param is being deprecated and hence we need to switch to new method. 


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->