### PR TITLE
fix tests failing due to missing expectation

### DIFF
--- a/internal/resources/common/meta_flatten_test.go
+++ b/internal/resources/common/meta_flatten_test.go
@@ -36,10 +36,11 @@ func TestFlattenMeta(t *testing.T) {
 			},
 			expected: []interface{}{
 				map[string]interface{}{
-					annotationsKey: map[string]string{"test": "test"},
-					LabelsKey:      map[string]string{"test": "test"},
-					DescriptionKey: "description of resource",
-					uidKey:         "abc",
+					annotationsKey:     map[string]string{"test": "test"},
+					LabelsKey:          map[string]string{"test": "test"},
+					DescriptionKey:     "description of resource",
+					resourceVersionKey: "",
+					uidKey:             "abc",
 				},
 			},
 		},
@@ -53,10 +54,11 @@ func TestFlattenMeta(t *testing.T) {
 			},
 			expected: []interface{}{
 				map[string]interface{}{
-					annotationsKey: map[string]string{"test": "test"},
-					LabelsKey:      map[string]string{},
-					DescriptionKey: "description of resource",
-					uidKey:         "",
+					annotationsKey:     map[string]string{"test": "test"},
+					LabelsKey:          map[string]string{},
+					DescriptionKey:     "description of resource",
+					resourceVersionKey: "",
+					uidKey:             "",
 				},
 			},
 		},
@@ -70,10 +72,11 @@ func TestFlattenMeta(t *testing.T) {
 			},
 			expected: []interface{}{
 				map[string]interface{}{
-					annotationsKey: map[string]string{},
-					LabelsKey:      map[string]string{"test": "test"},
-					DescriptionKey: "",
-					uidKey:         "123",
+					annotationsKey:     map[string]string{},
+					LabelsKey:          map[string]string{"test": "test"},
+					DescriptionKey:     "",
+					resourceVersionKey: "",
+					uidKey:             "123",
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: John Weldon <jweldon@vmware.com>

1. **What this PR does / why we need it**:

The tests in `internal/resources/common` are failing due to expectations missing a field; for example:

```
    --- FAIL: TestFlattenMeta/normal_scenario_with_labels_and_UID_of_meta_data (0.00s)
        meta_flatten_test.go:86: 
                Error Trace:    meta_flatten_test.go:86
                Error:          Not equal: 
                                expected: []interface {}{map[string]interface {}{"annotations":map[string]string{}, "description":"", "labels":map[string]string{"test":"test"}, "uid":"123"}}
                                actual  : []interface {}{map[string]interface {}{"annotations":map[string]string{}, "description":"", "labels":map[string]string{"test":"test"}, "resource_version":"", "uid":"123"}}
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 ([]interface {}) (len=1) {
                                - (map[string]interface {}) (len=4) {
                                + (map[string]interface {}) (len=5) {
                                   (string) (len=11) "annotations": (map[string]string) {
                                @@ -8,2 +8,3 @@
                                   },
                                +  (string) (len=16) "resource_version": (string) "",
                                   (string) (len=3) "uid": (string) (len=3) "123"
                Test:           TestFlattenMeta/normal_scenario_with_labels_and_UID_of_meta_data
FAIL
FAIL    github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common    0.042s
```

This is a trivial fix to correct the expectations.