### PR TITLE
Address lint issues

### DIFF
--- a/internal/authctx/authentication.go
+++ b/internal/authctx/authentication.go
@@ -8,7 +8,7 @@ package authctx
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -84,7 +84,7 @@ func getBearerToken(cspEndpoint, cspToken string) (string, error) {
 		return "", err
 	}
 
-	respJSON, err := ioutil.ReadAll(resp.Body)
+	respJSON, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/client/transport/client.go
+++ b/internal/client/transport/client.go
@@ -10,7 +10,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"time"
@@ -150,13 +149,13 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 	var bodyReader *bytes.Reader
 
 	if request.Body != nil {
-		reqData, err := ioutil.ReadAll(request.Body)
+		reqData, err := io.ReadAll(request.Body)
 		if err != nil {
 			return nil, err
 		}
 
 		bodyReader = bytes.NewReader(reqData)
-		request.Body = ioutil.NopCloser(bodyReader) // prevents closing the body between retries
+		request.Body = io.NopCloser(bodyReader) // prevents closing the body between retries
 	}
 
 	var (

--- a/internal/client/transport/methods.go
+++ b/internal/client/transport/methods.go
@@ -8,7 +8,7 @@ package transport
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -75,7 +75,7 @@ func (c *Client) invokeAction(httpMethodType string, url string, request Request
 		_ = resp.Body.Close()
 	}()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrapf(err, "read %v response", httpMethodType)
 	}
@@ -104,7 +104,7 @@ func (c *Client) Delete(url string) error {
 		_ = resp.Body.Close()
 	}()
 
-	respBody, _ := ioutil.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		return clienterrors.ErrorWithHTTPCode(resp.StatusCode, errors.Errorf("delete request(%s) failed with status : %v, response: %v", url, resp.Status, string(respBody)))
@@ -125,7 +125,7 @@ func (c *Client) Get(url string, response Response) error {
 		_ = resp.Body.Close()
 	}()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "read response")
 	}

--- a/internal/resources/cluster/manifest/helper.go
+++ b/internal/resources/cluster/manifest/helper.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -171,7 +171,7 @@ func GetK8sManifest(depLink string) ([]byte, error) {
 
 	defer resp.Body.Close()
 
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Replace references to deprecated "io/ioutil" module

1. **What this PR does / why we need it**:  `make lint` no longer complains about deprecated go module "io/ioutil"


2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->