### PR TITLE
Use plugin version that matches tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,15 @@ ifeq ($(VERSION_TAG),)
 	VERSION_TAG := $(shell git describe --dirty --first-parent --always --tags)
 endif
 
+GOARCH := $(shell go env GOARCH)
+GOOS := $(shell go env GOOS)
+
 default: build
 
 build:
 	go build -o bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG)
-	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/darwin_amd64/
-	cp bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG) ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/darwin_amd64/
-
-build-arm:
-	go build -o bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG)
-	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/darwin_arm64/
-	cp bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG) ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/darwin_arm64/
+	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/$(GOOS)_$(GOARCH)/
+	cp bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG) ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/$(GOOS)_$(GOARCH)/
 
 clean-up:
 	rm -rf ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/*

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
 # Copyright © 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: MPL-2.0
 
+ifeq ($(VERSION_TAG),)
+	VERSION_TAG := $(shell git describe --dirty --first-parent --always --tags)
+endif
+
 default: build
 
 build:
-	go build -o bin/terraform-provider-tanzu-mission-control_v1.0.0
-	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_amd64/
-	cp bin/terraform-provider-tanzu-mission-control_v1.0.0 ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_amd64/
+	go build -o bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG)
+	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/darwin_amd64/
+	cp bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG) ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/darwin_amd64/
 
 build-arm:
-	go build -o bin/terraform-provider-tanzu-mission-control_v1.0.0
-	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_arm64/
-	cp bin/terraform-provider-tanzu-mission-control_v1.0.0 ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_arm64/
+	go build -o bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG)
+	mkdir -p ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/darwin_arm64/
+	cp bin/terraform-provider-tanzu-mission-control_$(VERSION_TAG) ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/$(VERSION_TAG:v%=%)/darwin_arm64/
 
 clean-up:
 	rm -rf ~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/*


### PR DESCRIPTION
1. **What this PR does / why we need it**:

    The `build` and `build-arm` targets for building local development versions were using the hard-coded version `1.0.0`

    This PR uses a generated version number, using the latest tag, thereby making it easier to keep multiple development versions of the plugin installed.

    With this fix, building the plugin locally on the current `main` branch would yield:

    `~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.1.2/darwin_amd64/terraform-provider-tanzu-mission-control_v1.1.2`,

    instead of the hard-coded:

    `~/.terraform.d/plugins/vmware/dev/tanzu-mission-control/1.0.0/darwin_amd64/terraform-provider-tanzu-mission-control_v1.0.0`



    Additionally, instead of using two different make targets, the `build` target will place the generated binary in the directory that reflects the arch and os.