### PR TITLE
Adding checks in data source of cluster resource for handling corner cases

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -11,7 +11,10 @@ import (
 	"os"
 )
 
-const DEV = "DEV"
+const (
+	DEV     = "DEV"
+	TmcMode = "TMC_MODE"
+)
 
 func GetFirstElementOf(parent string, children ...string) (key string) {
 	if len(children) == 0 {
@@ -32,7 +35,7 @@ func readFloat(input interface{}, key string) float64 {
 	if !ok {
 		fmt.Printf("[ERROR]: Unable to covert %T to float64 for attribute %s \n", input, key)
 
-		if os.Getenv("TMC_MODE") == DEV {
+		if os.Getenv(TmcMode) == DEV {
 			log.Fatalf("[ERROR]: Invalid type conversion for the %s. Please check the schema", key)
 		}
 	}
@@ -45,7 +48,7 @@ func readInt(input interface{}, key string) int {
 	if !ok {
 		fmt.Printf("[ERROR]: Unable to covert %T to int for attribute %s \n", input, key)
 
-		if os.Getenv("TMC_MODE") == DEV {
+		if os.Getenv(TmcMode) == DEV {
 			log.Fatalf("[ERROR]: Invalid type conversion for the %s. Please check the schema", key)
 		}
 	}
@@ -58,7 +61,7 @@ func readBool(input interface{}, key string) bool {
 	if !ok {
 		fmt.Printf("[ERROR]: Unable to covert %T to bool for attribute %s \n", input, key)
 
-		if os.Getenv("TMC_MODE") == DEV {
+		if os.Getenv(TmcMode) == DEV {
 			log.Fatalf("[ERROR]: Invalid type conversion for the %s. Please check the schema", key)
 		}
 	}
@@ -71,7 +74,7 @@ func readString(input interface{}, key string) string {
 	if !ok {
 		fmt.Printf("[ERROR]: Unable to covert %T to string for attribute %s \n", input, key)
 
-		if os.Getenv("TMC_MODE") == DEV {
+		if os.Getenv(TmcMode) == DEV {
 			log.Fatalf("[ERROR]: Invalid type conversion for the %s. Please check the schema", key)
 		}
 	}
@@ -113,7 +116,7 @@ func SetPrimitiveValue(input, model interface{}, key string) {
 	default:
 		fmt.Printf("[ERROR]: Internal err, invalid use of SetPrimitive function for %s", key)
 
-		if os.Getenv("TMC_MODE") == DEV {
+		if os.Getenv(TmcMode) == DEV {
 			log.Fatalf("[ERROR}: SetPrimitive works on PassByReference and only for Primitive types. Got [%T]", m)
 		}
 	}

--- a/internal/resources/cluster/data_source_cluster.go
+++ b/internal/resources/cluster/data_source_cluster.go
@@ -129,18 +129,34 @@ func dataSourceTMCClusterRead(ctx context.Context, d *schema.ResourceData, m int
 
 	clusterSpec := constructSpec(d)
 
-	switch {
-	case resp.Cluster.Spec.TkgAws != nil:
-		resp.Cluster.Spec.TkgAws.Topology.NodePools = clusterSpec.TkgAws.Topology.NodePools
-	case resp.Cluster.Spec.TkgServiceVsphere != nil:
-		resp.Cluster.Spec.TkgServiceVsphere.Topology.NodePools = clusterSpec.TkgServiceVsphere.Topology.NodePools
-	case resp.Cluster.Spec.TkgVsphere != nil:
-		resp.Cluster.Spec.TkgVsphere.Topology.NodePools = clusterSpec.TkgVsphere.Topology.NodePools
-	}
+	getNodepoolForCluster(resp.Cluster.Spec, clusterSpec)
 
 	if err := d.Set(SpecKey, flattenSpec(resp.Cluster.Spec)); err != nil {
 		return diag.FromErr(err)
 	}
 
 	return diags
+}
+
+func getNodepoolForCluster(respSpec, clusterSpec *clustermodel.VmwareTanzuManageV1alpha1ClusterSpec) {
+	if clusterSpec == nil {
+		return
+	}
+
+	switch {
+	case clusterSpec.TkgAws == nil || clusterSpec.TkgServiceVsphere == nil || clusterSpec.TkgVsphere == nil:
+		break
+	case respSpec.TkgAws != nil:
+		if respSpec.TkgAws.Topology != nil && clusterSpec.TkgAws != nil && clusterSpec.TkgAws.Topology != nil {
+			respSpec.TkgAws.Topology.NodePools = clusterSpec.TkgAws.Topology.NodePools
+		}
+	case respSpec.TkgServiceVsphere != nil:
+		if respSpec.TkgServiceVsphere.Topology != nil && clusterSpec.TkgServiceVsphere != nil && clusterSpec.TkgServiceVsphere.Topology != nil {
+			respSpec.TkgServiceVsphere.Topology.NodePools = clusterSpec.TkgServiceVsphere.Topology.NodePools
+		}
+	case respSpec.TkgVsphere != nil:
+		if respSpec.TkgVsphere.Topology != nil && clusterSpec.TkgVsphere != nil && clusterSpec.TkgVsphere.Topology != nil {
+			respSpec.TkgVsphere.Topology.NodePools = clusterSpec.TkgVsphere.Topology.NodePools
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Vasundhara Shukla <vasundharas@vmware.com>

1. **What this PR does / why we need it**:
Adding checks to cluster data source to prevent nil pointer referencing.

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #74 


