### PR TITLE
Adding checks in data source of cluster to distinguish between read call for cluster data-source and for cluster resource

### DIFF
--- a/internal/resources/cluster/data_source_cluster.go
+++ b/internal/resources/cluster/data_source_cluster.go
@@ -127,20 +127,29 @@ func dataSourceTMCClusterRead(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	clusterSpec := constructSpec(d)
-
-	switch {
-	case resp.Cluster.Spec.TkgAws != nil:
-		resp.Cluster.Spec.TkgAws.Topology.NodePools = clusterSpec.TkgAws.Topology.NodePools
-	case resp.Cluster.Spec.TkgServiceVsphere != nil:
-		resp.Cluster.Spec.TkgServiceVsphere.Topology.NodePools = clusterSpec.TkgServiceVsphere.Topology.NodePools
-	case resp.Cluster.Spec.TkgVsphere != nil:
-		resp.Cluster.Spec.TkgVsphere.Topology.NodePools = clusterSpec.TkgVsphere.Topology.NodePools
-	}
+	setNodepoolForClusterResource(resp.Cluster.Spec, constructSpec(d))
 
 	if err := d.Set(SpecKey, flattenSpec(resp.Cluster.Spec)); err != nil {
 		return diag.FromErr(err)
 	}
 
 	return diags
+}
+
+func setNodepoolForClusterResource(respSpec, clusterSpec *clustermodel.VmwareTanzuManageV1alpha1ClusterSpec) {
+	if clusterSpec == nil {
+		return
+	}
+
+	switch {
+	// check for data-source read because only full name will be provided in terraform state file [spec will be empty].
+	case clusterSpec.TkgAws == nil && clusterSpec.TkgServiceVsphere == nil && clusterSpec.TkgVsphere == nil:
+		return
+	case clusterSpec.TkgAws != nil && clusterSpec.TkgAws.Topology != nil && respSpec.TkgAws.Topology != nil:
+		respSpec.TkgAws.Topology.NodePools = clusterSpec.TkgAws.Topology.NodePools
+	case clusterSpec.TkgServiceVsphere != nil && clusterSpec.TkgServiceVsphere.Topology != nil && respSpec.TkgServiceVsphere.Topology != nil:
+		respSpec.TkgServiceVsphere.Topology.NodePools = clusterSpec.TkgServiceVsphere.Topology.NodePools
+	case clusterSpec.TkgVsphere != nil && clusterSpec.TkgVsphere.Topology != nil && respSpec.TkgVsphere.Topology != nil:
+		respSpec.TkgVsphere.Topology.NodePools = clusterSpec.TkgVsphere.Topology.NodePools
+	}
 }

--- a/internal/resources/cluster/get_nodepool_test.go
+++ b/internal/resources/cluster/get_nodepool_test.go
@@ -1,0 +1,454 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+	tkgawsmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgaws"
+	tkgservicevspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgservicevsphere"
+	tkgvspheremodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/tkgvsphere"
+)
+
+func TestGetNodepoolForCluster(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description      string
+		inputRespSpec    *clustermodel.VmwareTanzuManageV1alpha1ClusterSpec
+		inputClusterSpec *clustermodel.VmwareTanzuManageV1alpha1ClusterSpec
+		expectedSpec     *clustermodel.VmwareTanzuManageV1alpha1ClusterSpec
+	}{
+		{
+			description:      "check for nil data in cluster spec",
+			inputClusterSpec: nil,
+			inputRespSpec:    nil,
+			expectedSpec:     nil,
+		},
+		{
+			description: "scenario for attach cluster",
+			inputClusterSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+			},
+			inputRespSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+			},
+			expectedSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+			},
+		},
+		{
+			description: "scenario for TKG AWS spec",
+			inputClusterSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgAws: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsSpec{
+					Topology: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									WorkerNodeCount: "1",
+									TkgAws: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGAWSNodepool{
+										AvailabilityZone: "us-west-2a",
+										InstanceType:     "m5.large",
+										NodePlacement: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGAWSNodePlacement{
+											{
+												AvailabilityZone: "us-west-2a",
+											},
+										},
+										SubnetID: "default",
+										Version:  "v1.21.2+vmware.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputRespSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgAws: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsSpec{
+					Topology: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									WorkerNodeCount: "1",
+									TkgAws: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGAWSNodepool{
+										AvailabilityZone: "us-east-2a",
+										InstanceType:     "m5.large",
+										NodePlacement: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGAWSNodePlacement{
+											{
+												AvailabilityZone: "us-west-2a",
+											},
+										},
+										SubnetID: "default",
+										Version:  "v1.21.2+vmware.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgAws: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsSpec{
+					Topology: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									WorkerNodeCount: "1",
+									TkgAws: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGAWSNodepool{
+										AvailabilityZone: "us-west-2a",
+										InstanceType:     "m5.large",
+										NodePlacement: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGAWSNodePlacement{
+											{
+												AvailabilityZone: "us-west-2a",
+											},
+										},
+										SubnetID: "default",
+										Version:  "v1.21.2+vmware.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "scenario for TKG AWS spec topology is nil",
+			inputClusterSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgAws: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsSpec{
+					Topology: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									WorkerNodeCount: "1",
+									TkgAws: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGAWSNodepool{
+										AvailabilityZone: "us-west-2a",
+										InstanceType:     "m5.large",
+										NodePlacement: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGAWSNodePlacement{
+											{
+												AvailabilityZone: "us-west-2a",
+											},
+										},
+										SubnetID: "default",
+										Version:  "v1.21.2+vmware.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputRespSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgAws: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsSpec{
+					Topology: nil,
+				},
+			},
+			expectedSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgAws: &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsSpec{
+					Topology: nil,
+				},
+			},
+		},
+		{
+			description: "scenario for TKG vSphere spec",
+			inputClusterSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgVsphere: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereSpec{
+					Topology: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									WorkerNodeCount: "1",
+									TkgVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGVsphereNodepool{
+										VMConfig: &nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGVsphereVMConfig{
+											CPU:       "2",
+											DiskGib:   "40",
+											MemoryMib: "8192",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputRespSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgVsphere: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereSpec{
+					Topology: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									WorkerNodeCount: "1",
+									TkgVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGVsphereNodepool{
+										VMConfig: &nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGVsphereVMConfig{
+											CPU:       "2",
+											DiskGib:   "40",
+											MemoryMib: "8192",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgVsphere: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereSpec{
+					Topology: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									WorkerNodeCount: "1",
+									TkgVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGVsphereNodepool{
+										VMConfig: &nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGVsphereVMConfig{
+											CPU:       "2",
+											DiskGib:   "40",
+											MemoryMib: "8192",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "scenario for TKG vSphere spec topology is nil",
+			inputClusterSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgVsphere: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereSpec{
+					Topology: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									WorkerNodeCount: "1",
+									TkgVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGVsphereNodepool{
+										VMConfig: &nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGVsphereVMConfig{
+											CPU:       "2",
+											DiskGib:   "40",
+											MemoryMib: "8192",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputRespSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgVsphere: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereSpec{
+					Topology: nil,
+				},
+			},
+			expectedSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgVsphere: &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereSpec{
+					Topology: nil,
+				},
+			},
+		},
+		{
+			description: "scenario for TKGs spec",
+			inputClusterSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgServiceVsphere: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereSpec{
+					Topology: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									CloudLabels:     map[string]string{"cloud-key": "cloud-value"},
+									NodeLabels:      map[string]string{"node-key": "node-value"},
+									WorkerNodeCount: "1",
+									TkgServiceVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGServiceVsphereNodepool{
+										Class:        "test-class-spec",
+										StorageClass: "test-storage-spec",
+										Volumes: []*nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGServiceVsphereVolume{
+											{
+												Capacity:     4,
+												MountPath:    "/var/lib/etcd",
+												Name:         "etcd-0",
+												StorageClass: "tkgs-k8s-obj-policy",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputRespSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgServiceVsphere: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereSpec{
+					Topology: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									CloudLabels:     map[string]string{"cloud-key": "cloud-value"},
+									NodeLabels:      map[string]string{"node-key": "node-value"},
+									WorkerNodeCount: "1",
+									TkgServiceVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGServiceVsphereNodepool{
+										Class:        "test-class-spec",
+										StorageClass: "test-storage-spec",
+										Volumes: []*nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGServiceVsphereVolume{
+											{
+												Capacity:     4,
+												MountPath:    "/var/lib/etcd",
+												Name:         "etcd-0",
+												StorageClass: "tkgs-k8s-obj-policy",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgServiceVsphere: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereSpec{
+					Topology: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									CloudLabels:     map[string]string{"cloud-key": "cloud-value"},
+									NodeLabels:      map[string]string{"node-key": "node-value"},
+									WorkerNodeCount: "1",
+									TkgServiceVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGServiceVsphereNodepool{
+										Class:        "test-class-spec",
+										StorageClass: "test-storage-spec",
+										Volumes: []*nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGServiceVsphereVolume{
+											{
+												Capacity:     4,
+												MountPath:    "/var/lib/etcd",
+												Name:         "etcd-0",
+												StorageClass: "tkgs-k8s-obj-policy",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "scenario for TKGs spec topology is nil",
+			inputClusterSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgServiceVsphere: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereSpec{
+					Topology: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereTopology{
+						NodePools: []*nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
+							{
+								Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{
+									Name:        "test",
+									Description: "testing get nodepool function",
+								},
+								Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{
+									CloudLabels:     map[string]string{"cloud-key": "cloud-value"},
+									NodeLabels:      map[string]string{"node-key": "node-value"},
+									WorkerNodeCount: "1",
+									TkgServiceVsphere: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolTKGServiceVsphereNodepool{
+										Class:        "test-class-spec",
+										StorageClass: "test-storage-spec",
+										Volumes: []*nodepoolmodel.VmwareTanzuManageV1alpha1CommonClusterTKGServiceVsphereVolume{
+											{
+												Capacity:     4,
+												MountPath:    "/var/lib/etcd",
+												Name:         "etcd-0",
+												StorageClass: "tkgs-k8s-obj-policy",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputRespSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgServiceVsphere: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereSpec{
+					Topology: nil,
+				},
+			},
+			expectedSpec: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				TkgServiceVsphere: &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereSpec{
+					Topology: nil,
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			setNodepoolForClusterResource(test.inputRespSpec, test.inputClusterSpec)
+			require.Equal(t, test.expectedSpec, test.inputRespSpec)
+		})
+	}
+}

--- a/internal/resources/cluster/tkgaws/resource_tkg_aws.go
+++ b/internal/resources/cluster/tkgaws/resource_tkg_aws.go
@@ -619,8 +619,8 @@ func expandTKGAWSTopology(data []interface{}) (topology *tkgawsmodel.VmwareTanzu
 	topology = &tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsTopology{}
 
 	if v, ok := lookUpTopology[controlPlaneKey]; ok {
-		if v1, ok := v.([]interface{}); ok {
-			topology.ControlPlane = expandTKGAWSTopologyControlPlane(v1)
+		if cp, ok := v.([]interface{}); ok {
+			topology.ControlPlane = expandTKGAWSTopologyControlPlane(cp)
 		}
 	}
 
@@ -812,7 +812,11 @@ var tkgAWSNodePoolSpec = &schema.Schema{
 }
 
 func expandTKGAWSTopologyNodePool(data interface{}) (nodePools *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition) {
-	lookUpNodepool := data.(map[string]interface{})
+	lookUpNodepool, ok := data.(map[string]interface{})
+	if !ok {
+		return nodePools
+	}
+
 	nodePools = &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
 		Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{},
 		Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{},

--- a/internal/resources/cluster/tkgservicevsphere/resource_tkg_service_vsphere.go
+++ b/internal/resources/cluster/tkgservicevsphere/resource_tkg_service_vsphere.go
@@ -337,16 +337,18 @@ func expandTKGSTopology(data []interface{}) (topology *tkgservicevspheremodel.Vm
 		return topology
 	}
 
-	topology = &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereTopology{}
 	topologyData, _ := data[0].(map[string]interface{})
+	topology = &tkgservicevspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgservicevsphereTopology{}
 
 	if v, ok := topologyData[controlPlaneKey]; ok {
-		topology.ControlPlane = expandTKGSTopologyControlPlane(v.([]interface{}))
+		if cp, ok := v.([]interface{}); ok {
+			topology.ControlPlane = expandTKGSTopologyControlPlane(cp)
+		}
 	}
 
 	if v, ok := topologyData[nodePoolsKey]; ok {
-		nodePools, _ := v.([]interface{})
-		for _, np := range nodePools {
+		nodepools, _ := v.([]interface{})
+		for _, np := range nodepools {
 			topology.NodePools = append(topology.NodePools, expandTKGSTopologyNodePool(np))
 		}
 	}
@@ -366,7 +368,7 @@ func flattenTKGSTopology(topology *tkgservicevspheremodel.VmwareTanzuManageV1alp
 	nodePools := make([]interface{}, 0)
 
 	for _, nodePool := range topology.NodePools {
-		nodePools = append(nodePools, FlattenTKGSTopologyNodePool(nodePool))
+		nodePools = append(nodePools, flattenTKGSTopologyNodePool(nodePool))
 	}
 
 	flattenTopology[nodePoolsKey] = nodePools
@@ -605,7 +607,11 @@ var storageClass = &schema.Schema{
 }
 
 func expandTKGSTopologyNodePool(data interface{}) (nodePools *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition) {
-	nodePoolData := data.(map[string]interface{})
+	nodePoolData, ok := data.(map[string]interface{})
+	if !ok {
+		return nodePools
+	}
+
 	nodePools = &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
 		Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{},
 		Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{},
@@ -682,7 +688,7 @@ func expandNodePoolTKGSServiceVsphere(data []interface{}) (tkgsServiceVsphere *n
 	return tkgsServiceVsphere
 }
 
-func FlattenTKGSTopologyNodePool(nodePool *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition) (data interface{}) {
+func flattenTKGSTopologyNodePool(nodePool *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition) (data interface{}) {
 	flattenNodePool := make(map[string]interface{})
 
 	if nodePool == nil {

--- a/internal/resources/cluster/tkgvsphere/resource_tkgvsphere.go
+++ b/internal/resources/cluster/tkgvsphere/resource_tkgvsphere.go
@@ -438,8 +438,8 @@ func expandTKGVsphereTopology(data []interface{}) (topology *tkgvspheremodel.Vmw
 	topology = &tkgvspheremodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgvsphereTopology{}
 
 	if v, ok := lookUpTopology[controlPlaneKey]; ok {
-		if v1, ok := v.([]interface{}); ok {
-			topology.ControlPlane = expandTKGVsphereTopologyControlPlane(v1)
+		if cp, ok := v.([]interface{}); ok {
+			topology.ControlPlane = expandTKGVsphereTopologyControlPlane(cp)
 		}
 	}
 
@@ -605,7 +605,11 @@ var tkgVsphereNodePoolSpec = &schema.Schema{
 }
 
 func expandTKGVsphereTopologyNodePool(data interface{}) (nodePools *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition) {
-	lookUpNodepool := data.(map[string]interface{})
+	lookUpNodepool, ok := data.(map[string]interface{})
+	if !ok {
+		return nodePools
+	}
+
 	nodePools = &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolDefinition{
 		Spec: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolSpec{},
 		Info: &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolInfo{},


### PR DESCRIPTION
Signed-off-by: Vasundhara Shukla <vasundharas@vmware.com>

1. **What this PR does / why we need it**:
Adding checks to cluster data source to prevent nil pointer referencing.

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #74 

3. Testing Reference:


<img width="1182" alt="Screenshot 2022-10-23 at 12 02 32 AM" src="https://user-images.githubusercontent.com/32017029/197535317-852f1b74-0f75-4f43-b871-01bb8643eb94.png">


<img width="1545" alt="Screenshot 2022-10-23 at 12 02 00 AM" src="https://user-images.githubusercontent.com/32017029/197535369-cbc79a10-e73a-42d0-b9f6-e2a60a89d154.png">


Terraform State file contents:

`{
  "version": 4,
  "terraform_version": "1.0.5",
  "serial": 4,
  "lineage": "4d0dab08-2805-b886-a086-dfdff9d35e48",
  "outputs": {},
  "resources": [
    {
      "mode": "data",
      "type": "tanzu-mission-control_cluster",
      "name": "read_tkg_aws_cluster",
      "provider": "provider[\"vmware/dev/tanzu-mission-control\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attach_k8s_cluster": null,
            "id": "c:01GG0ETTZB13T4FJNGBK5R3QF0",
            "management_cluster_name": "vasundhara-tkgm-mc-vc7",
            "meta": [
              {
                "annotations": {
                  "authoritativeRID": "rid:c:886a0206-49c4-4af8-ab01-f7becc5af7ce:vasundhara-tkgm-mc-vc7:default:tkgm-workload"
                },
                "description": "description of the cluster",
                "labels": {
                  "key": "value",
                  "tmc.cloud.vmware.com/creator": "vasundharas"
                },
                "resource_version": "551115:3182567",
                "uid": "c:01GG0ETTZB13T4FJNGBK5R3QF0"
              }
            ],
            "name": "tkgm-workload",
            "provisioner_name": "default",
            "ready_wait_timeout": "default",
            "spec": [
              {
                "cluster_group": "default",
                "proxy": "",
                "tkg_aws": [],
                "tkg_service_vsphere": [],
                "tkg_vsphere": [
                  {
                    "distribution": [
                      {
                        "version": "v1.22.9+vmware.1-tkg.1",
                        "workspace": [
                          {
                            "datacenter": "/dc0",
                            "datastore": "/dc0/datastore/sharedVmfs-0",
                            "folder": "/dc0/vm/folder0",
                            "resource_pool": "/dc0/host/cluster0/Resources/rp0",
                            "workspace_network": "/dc0/network/VM Network"
                          }
                        ]
                      }
                    ],
                    "settings": [
                      {
                        "network": [
                          {
                            "api_server_port": 6443,
                            "control_plane_end_point": "10.191.242.114",
                            "pods": [
                              {
                                "cidr_blocks": [
                                  "100.96.0.0/11"
                                ]
                              }
                            ],
                            "services": [
                              {
                                "cidr_blocks": [
                                  "100.64.0.0/13"
                                ]
                              }
                            ]
                          }
                        ],
                        "security": [
                          {
                            "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCZ6M2makyArGMd8lRoodwlAx5tpIaEBaj6l3b/St73WMlJYeDemuWfwPKiOFNQi0LGu751GDPHYRMN+flX8z6mioa9Apuir9f+1f7E9OOcG9R3XAZ5O4rOFbK8CQQDz0snppGUC7cRx7l7/Kr9sepELLj/Vwhb3/g/POl6cyWOmQ=="
                          }
                        ]
                      }
                    ],
                    "topology": [
                      {
                        "control_plane": [
                          {
                            "high_availability": false,
                            "vm_config": [
                              {
                                "cpu": "2",
                                "disk_size": "20",
                                "memory": "4096"
                              }
                            ]
                          }
                        ],
                        "node_pools": []
                      }
                    ]
                  }
                ]
              }
            ],
            "status": {
              "health": "HEALTHY",
              "infra_provider": "VMWARE_VSPHERE",
              "infra_provider_region": "",
              "k8s_provider_type": "VMWARE_TANZU_KUBERNETES_GRID",
              "k8s_provider_version": "v1.5.4",
              "k8s_version": "v1.22.9+vmware.1",
              "node_count": "2",
              "phase": "READY",
              "type": "TANZU_KUBERNETES_GRID"
            }
          },
          "sensitive_attributes": []
        }
      ]
    },
    {
      "mode": "managed",
      "type": "tanzu-mission-control_cluster",
      "name": "create_tkg_vsphere_cluster",
      "provider": "provider[\"vmware/dev/tanzu-mission-control\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attach_k8s_cluster": [],
            "id": "c:01GG0ETTZB13T4FJNGBK5R3QF0",
            "management_cluster_name": "vasundhara-tkgm-mc-vc7",
            "meta": [
              {
                "annotations": {
                  "authoritativeRID": "rid:c:886a0206-49c4-4af8-ab01-f7becc5af7ce:vasundhara-tkgm-mc-vc7:default:tkgm-workload"
                },
                "description": "description of the cluster",
                "labels": {
                  "key": "value",
                  "tmc.cloud.vmware.com/creator": "vasundharas"
                },
                "resource_version": "551115:3182567",
                "uid": "c:01GG0ETTZB13T4FJNGBK5R3QF0"
              }
            ],
            "name": "tkgm-workload",
            "provisioner_name": "default",
            "ready_wait_timeout": "default",
            "spec": [
              {
                "cluster_group": "default",
                "proxy": "",
                "tkg_aws": [],
                "tkg_service_vsphere": [],
                "tkg_vsphere": [
                  {
                    "distribution": [
                      {
                        "version": "v1.22.9+vmware.1-tkg.1",
                        "workspace": [
                          {
                            "datacenter": "/dc0",
                            "datastore": "/dc0/datastore/sharedVmfs-0",
                            "folder": "/dc0/vm/folder0",
                            "resource_pool": "/dc0/host/cluster0/Resources/rp0",
                            "workspace_network": "/dc0/network/VM Network"
                          }
                        ]
                      }
                    ],
                    "settings": [
                      {
                        "network": [
                          {
                            "api_server_port": 6443,
                            "control_plane_end_point": "10.191.242.114",
                            "pods": [
                              {
                                "cidr_blocks": [
                                  "100.96.0.0/11"
                                ]
                              }
                            ],
                            "services": [
                              {
                                "cidr_blocks": [
                                  "100.64.0.0/13"
                                ]
                              }
                            ]
                          }
                        ],
                        "security": [
                          {
                            "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCZ6M2makyArGMd8lRoodwlAx5tpIaEBaj6l3b/St73WMlJYeDemuWfwPKiOFNQi0LGu751GDPHYRMN+flX8z6mioa9Apuir9f+1f7E9OOcG9R3XAZ5O4rOFbK8CQQDz0snppGUC7cRx7l7/Kr9sepELLj/Vwhb3/g/POl6cyWOmQ=="
                          }
                        ]
                      }
                    ],
                    "topology": [
                      {
                        "control_plane": [
                          {
                            "high_availability": false,
                            "vm_config": [
                              {
                                "cpu": "2",
                                "disk_size": "20",
                                "memory": "4096"
                              }
                            ]
                          }
                        ],
                        "node_pools": [
                          {
                            "info": [
                              {
                                "description": "my nodepool",
                                "name": "default-nodepool"
                              }
                            ],
                            "spec": [
                              {
                                "tkg_vsphere": [
                                  {
                                    "vm_config": [
                                      {
                                        "cpu": "2",
                                        "disk_size": "40",
                                        "memory": "4096"
                                      }
                                    ]
                                  }
                                ],
                                "worker_node_count": "1"
                              }
                            ]
                          }
                        ]
                      }
                    ]
                  }
                ]
              }
            ],
            "status": {
              "health": "HEALTHY",
              "infra_provider": "VMWARE_VSPHERE",
              "infra_provider_region": "",
              "k8s_provider_type": "VMWARE_TANZU_KUBERNETES_GRID",
              "k8s_provider_version": "v1.5.4",
              "k8s_version": "v1.22.9+vmware.1",
              "node_count": "2",
              "phase": "READY",
              "type": "TANZU_KUBERNETES_GRID"
            }
          },
          "sensitive_attributes": [],
          "private": "bnVsbA=="
        }
      ]
    }
  ]
}
`