### PR TITLE
Add image registry policy resource with scope and flatten tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9
 	k8s.io/apiextensions-apiserver v0.18.2
 	k8s.io/apimachinery v0.22.0
 	k8s.io/client-go v0.22.0
@@ -37,7 +38,7 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -81,7 +82,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,9 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -651,6 +652,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9 h1:yZNXmy+j/JpX19vZkVktWqAo7Gny4PBWYYK3zskGpx4=
+golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -790,8 +793,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -118,3 +118,7 @@ func SetPrimitiveValue(input, model interface{}, key string) {
 		}
 	}
 }
+
+func BoolPointer(b bool) *bool {
+	return &b
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,7 +38,7 @@ func Provider() *schema.Provider {
 			iampolicy.ResourceName:      iampolicy.ResourceIAMPolicy(),
 			custompolicy.ResourceName:   custompolicyresource.ResourceCustomPolicy(),
 			securitypolicy.ResourceName: securitypolicyresource.ResourceSecurityPolicy(),
-			imagepolicy.ResourceName:    imagepolicyresource.ResourceImageRegistryPolicy(),
+			imagepolicy.ResourceName:    imagepolicyresource.ResourceImagePolicy(),
 			credential.ResourceName:     credential.ResourceCredential(),
 			integration.ResourceName:    integration.ResourceIntegration(),
 		},

--- a/internal/resources/policy/kind/custom/recipe/tmc_block_rolebinding_subjects_flatten_test.go
+++ b/internal/resources/policy/kind/custom/recipe/tmc_block_rolebinding_subjects_flatten_test.go
@@ -29,7 +29,7 @@ func TestFlattenTMCBlockRolebindingSubjects(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_block_rolebinding_subjects recipe",
+			description: "normal scenario with complete custom policy tmc_block_rolebinding_subjects recipe",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCBlockRoleBindingSubjects{
 				Audit: true,
 				Parameters: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCBlockRoleBindingSubjectsParameters{
@@ -94,7 +94,7 @@ func TestFlattenBlockRoleBindingParameters(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_block_rolebinding_subjects parameters",
+			description: "normal scenario with complete custom policy tmc_block_rolebinding_subjects parameters",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCBlockRoleBindingSubjectsParameters{
 				DisallowedSubjects: []*policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCBlockRoleBindingSubjectsParametersDisallowedSubjects{
 					{
@@ -139,7 +139,7 @@ func TestFlattenDisallowedSubjects(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_block_rolebinding_subjects parameters disallowed subjects",
+			description: "normal scenario with complete custom policy tmc_block_rolebinding_subjects parameters disallowed subjects",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCBlockRoleBindingSubjectsParametersDisallowedSubjects{
 				Kind: "nodes",
 				Name: "test",

--- a/internal/resources/policy/kind/custom/recipe/tmc_common_recipe_flatten_test.go
+++ b/internal/resources/policy/kind/custom/recipe/tmc_common_recipe_flatten_test.go
@@ -14,7 +14,7 @@ import (
 	policyrecipecustomcommonmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/custom/common"
 )
 
-func TestFlattenTMCBlockNodeportService(t *testing.T) {
+func TestFlattenTMCCommonRecipe(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -23,12 +23,12 @@ func TestFlattenTMCBlockNodeportService(t *testing.T) {
 		expected    []interface{}
 	}{
 		{
-			description: "check for nil custom policy tmc_block_nodeport_service recipe",
+			description: "check for nil custom policy tmc-block-nodeport-service/ tmc-block-resources/ tmc-https-ingress recipes",
 			input:       nil,
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_block_nodeport_service recipe",
+			description: "normal scenario with complete custom policy tmc-block-nodeport-service/ tmc-block-resources/ tmc-https-ingress recipes",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCCommonRecipe{
 				Audit: true,
 				TargetKubernetesResources: []*policyrecipecustomcommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TargetKubernetesResources{

--- a/internal/resources/policy/kind/custom/recipe/tmc_external_ips_flatten_test.go
+++ b/internal/resources/policy/kind/custom/recipe/tmc_external_ips_flatten_test.go
@@ -28,7 +28,7 @@ func TestFlattenTMCExternalIPS(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_external_ips recipe",
+			description: "normal scenario with complete custom policy tmc_external_ips recipe",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCExternalIPS{
 				Audit: true,
 				Parameters: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCExternalIPSParameters{
@@ -83,7 +83,7 @@ func TestFlattenExternalIPSParameters(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_external_ips parameters",
+			description: "normal scenario with complete custom policy tmc_external_ips parameters",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCExternalIPSParameters{
 				AllowedIPs: []string{"127.0.0.1"},
 			},

--- a/internal/resources/policy/kind/custom/recipe/tmc_require_labels_flatten_test.go
+++ b/internal/resources/policy/kind/custom/recipe/tmc_require_labels_flatten_test.go
@@ -29,7 +29,7 @@ func TestFlattenTMCRequireLabels(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_require_labels recipe",
+			description: "normal scenario with complete custom policy tmc_require_labels recipe",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCRequireLabels{
 				Audit: true,
 				Parameters: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCRequireLabelsParameters{
@@ -94,7 +94,7 @@ func TestFlattenRequiredLabelsParameters(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_require_labels parameters",
+			description: "normal scenario with complete custom policy tmc_require_labels parameters",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCRequireLabelsParameters{
 				Labels: []*policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCRequireLabelsParametersLabels{
 					{
@@ -139,7 +139,7 @@ func TestFlattenRequiredLabelsParametersLabels(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "normal scenario with with complete custom policy tmc_require_labels parameters labels",
+			description: "normal scenario with complete custom policy tmc_require_labels parameters labels",
 			input: &policyrecipecustommodel.VmwareTanzuManageV1alpha1CommonPolicySpecCustomV1TMCRequireLabelsParametersLabels{
 				Key:   "key-1",
 				Value: "value-1",

--- a/internal/resources/policy/kind/custom/resource/resource_custom_policy.go
+++ b/internal/resources/policy/kind/custom/resource/resource_custom_policy.go
@@ -24,7 +24,7 @@ func ResourceCustomPolicy() *schema.Resource {
 		DeleteContext: schema.DeleteContextFunc(policyoperations.ResourceOperation(policyoperations.WithResourceName(policykindcustom.ResourceName), policyoperations.WithOperationType(policyoperations.Delete))),
 		Schema:        customPolicySchema,
 		CustomizeDiff: customdiff.All(
-			scope.ValidateScope,
+			schema.CustomizeDiffFunc(scope.ValidateScope(policyoperations.ScopeMap[policykindcustom.ResourceName])),
 			policykindcustom.ValidateInput,
 			policy.ValidateSpecLabelSelectorRequirement,
 		),

--- a/internal/resources/policy/kind/custom/resource/resource_custom_policy_test.go
+++ b/internal/resources/policy/kind/custom/resource/resource_custom_policy_test.go
@@ -26,6 +26,7 @@ import (
 	policyorganizationmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/organization"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy"
 	policykindCustom "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/kind/custom"
+	policyoperations "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/operations"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/scope"
 	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
@@ -273,7 +274,7 @@ func TestAcceptanceForCustomPolicyResource(t *testing.T) {
 }
 
 func (testConfig *testAcceptanceConfig) getTestCustomPolicyResourceBasicConfigValue(scope scope.Scope, recipe policykindCustom.Recipe) string {
-	helperBlock, scopeBlock := testConfig.ScopeHelperResources.GetTestPolicyResourceHelperAndScope(scope)
+	helperBlock, scopeBlock := testConfig.ScopeHelperResources.GetTestPolicyResourceHelperAndScope(scope, policyoperations.ScopeMap[testConfig.CustomPolicyResource])
 	inputBlock := testConfig.getTestCustomPolicyResourceInput(recipe)
 
 	return fmt.Sprintf(`
@@ -455,7 +456,7 @@ func (testConfig *testAcceptanceConfig) checkCustomPolicyResourceAttributes(scop
 	case scope.OrganizationScope:
 		check = append(check, resource.TestCheckResourceAttr(testConfig.CustomPolicyResourceName, "scope.0.organization.0.organization", testConfig.ScopeHelperResources.OrgID))
 	case scope.UnknownScope:
-		log.Printf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scope.ScopesAllowed[:], `, `))
+		log.Printf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(policyoperations.ScopeMap[testConfig.CustomPolicyResource], `, `))
 	}
 
 	check = append(check, policy.MetaResourceAttributeCheck(testConfig.CustomPolicyResourceName)...)
@@ -536,7 +537,7 @@ func (testConfig *testAcceptanceConfig) verifyCustomPolicyResourceCreation(scope
 				return errors.Wrapf(err, "organization scoped custom policy resource is empty, resource: %s", testConfig.CustomPolicyResourceName)
 			}
 		case scope.UnknownScope:
-			return errors.Errorf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scope.ScopesAllowed[:], `, `))
+			return errors.Errorf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(policyoperations.ScopeMap[testConfig.CustomPolicyResource], `, `))
 		}
 
 		return nil

--- a/internal/resources/policy/kind/image/constants.go
+++ b/internal/resources/policy/kind/image/constants.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	ResourceName     = "tanzu-mission-control_image_registry_policy"
-	typeDefaultValue = "image-registry-policy"
+	ResourceName     = "tanzu-mission-control_image_policy"
+	typeDefaultValue = "image-policy"
 )
 
 // Allowed input recipes.

--- a/internal/resources/policy/kind/image/input_flatten_test.go
+++ b/internal/resources/policy/kind/image/input_flatten_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package policykindimage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	policyrecipeimagemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image"
+	reciperesource "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/kind/image/recipe"
+)
+
+func TestFlattenInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		input       *inputRecipe
+		expected    []interface{}
+	}{
+		{
+			description: "check for nil input",
+			input:       nil,
+			expected:    nil,
+		},
+		{
+			description: "normal scenario with complete input",
+			input: &inputRecipe{
+				recipe: BlockLatestTagRecipe,
+				inputBlockLatestTag: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CommonRecipe{
+					Audit: helper.BoolPointer(true),
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					reciperesource.BlockLatestTagKey: []interface{}{
+						map[string]interface{}{
+							reciperesource.AuditKey: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			actual := flattenInput(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/internal/resources/policy/kind/image/input_schema.go
+++ b/internal/resources/policy/kind/image/input_schema.go
@@ -20,7 +20,7 @@ import (
 var (
 	inputSchema = &schema.Schema{
 		Type:        schema.TypeList,
-		Description: "Input for the image registry policy, having one of the valid recipes: allowed-name-tag, custom, block-latest-tag or require-digest.",
+		Description: "Input for the image policy, having one of the valid recipes: allowed-name-tag, custom, block-latest-tag or require-digest.",
 		Required:    true,
 		MaxItems:    1,
 		MinItems:    1,
@@ -39,7 +39,7 @@ var (
 
 type (
 	Recipe string
-	// InputRecipe is a struct for all types of image registry policy inputs.
+	// InputRecipe is a struct for all types of image policy inputs.
 	inputRecipe struct {
 		recipe              Recipe
 		inputAllowedNameTag *policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTag

--- a/internal/resources/policy/kind/image/recipe/allowed_name_tag_flatten_test.go
+++ b/internal/resources/policy/kind/image/recipe/allowed_name_tag_flatten_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package recipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	policyrecipeimagemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image"
+	policyrecipeimagecommonmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image/common"
+)
+
+func TestFlattenAllowedNameTag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		input       *policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTag
+		expected    []interface{}
+	}{
+		{
+			description: "check for nil image policy allowed-name-tag recipe",
+			input:       nil,
+			expected:    nil,
+		},
+		{
+			description: "scenario with nil value of Audit value in allowed-name-tag recipe",
+			input: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTag{
+				Audit: nil,
+				Rules: []*policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTagRules{
+					{
+						ImageName: "foo",
+						Tag: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+							Negate: helper.BoolPointer(false),
+							Value:  "test",
+						},
+					},
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					RulesKey: []interface{}{
+						map[string]interface{}{
+							ImageNameKey: "foo",
+							TagKey: []interface{}{
+								map[string]interface{}{
+									NegateKey: false,
+									ValueKey:  "test",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "normal scenario with complete image policy allowed-name-tag recipe",
+			input: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTag{
+				Audit: helper.BoolPointer(true),
+				Rules: []*policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTagRules{
+					{
+						ImageName: "foo",
+						Tag: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+							Negate: helper.BoolPointer(false),
+							Value:  "test",
+						},
+					},
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					AuditKey: true,
+					RulesKey: []interface{}{
+						map[string]interface{}{
+							ImageNameKey: "foo",
+							TagKey: []interface{}{
+								map[string]interface{}{
+									NegateKey: false,
+									ValueKey:  "test",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			actual := FlattenAllowedNameTag(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestFlattenNameTagRules(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		input       *policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTagRules
+		expected    interface{}
+	}{
+		{
+			description: "check for nil rules value of allowed-name-tag recipe",
+			input:       nil,
+			expected:    nil,
+		},
+		{
+			description: "normal scenario with all fields of rules spec of allowed-name-tag recipe",
+			input: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTagRules{
+				ImageName: "foo",
+				Tag: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+					Negate: helper.BoolPointer(false),
+					Value:  "test",
+				},
+			},
+			expected: map[string]interface{}{
+				ImageNameKey: "foo",
+				TagKey: []interface{}{
+					map[string]interface{}{
+						NegateKey: false,
+						ValueKey:  "test",
+					},
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			actual := flattenNameTagRules(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/internal/resources/policy/kind/image/recipe/allowed_name_tag_schema.go
+++ b/internal/resources/policy/kind/image/recipe/allowed_name_tag_schema.go
@@ -57,7 +57,7 @@ func ConstructAllowedNameTag(data []interface{}) (nameTag *policyrecipeimagemode
 	nameTag = &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTag{}
 
 	if v, ok := allowedNameTagData[AuditKey]; ok {
-		helper.SetPrimitiveValue(v, &nameTag.Audit, AuditKey)
+		nameTag.Audit = helper.BoolPointer(v.(bool))
 	}
 
 	if v, ok := allowedNameTagData[RulesKey]; ok {
@@ -107,7 +107,9 @@ func FlattenAllowedNameTag(nameTag *policyrecipeimagemodel.VmwareTanzuManageV1al
 
 	flattenAllowedNameTag := make(map[string]interface{})
 
-	flattenAllowedNameTag[AuditKey] = nameTag.Audit
+	if nameTag.Audit != nil {
+		flattenAllowedNameTag[AuditKey] = *nameTag.Audit
+	}
 
 	if nameTag.Rules != nil {
 		var rules []interface{}

--- a/internal/resources/policy/kind/image/recipe/block_latest_tag-require_digest_flatten_test.go
+++ b/internal/resources/policy/kind/image/recipe/block_latest_tag-require_digest_flatten_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package recipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	policyrecipeimagemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image"
+)
+
+func TestFlattenCommonRecipe(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		input       *policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CommonRecipe
+		expected    []interface{}
+	}{
+		{
+			description: "check for nil image policy block-latest-tag or require-digest recipes",
+			input:       nil,
+			expected:    nil,
+		},
+		{
+			description: "scenario with nil data for Audit",
+			input: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CommonRecipe{
+				Audit: nil,
+			},
+			expected: nil,
+		},
+		{
+			description: "normal scenario with complete image policy block-latest-tag or require-digest recipes",
+			input: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CommonRecipe{
+				Audit: helper.BoolPointer(true),
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					AuditKey: true,
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			actual := FlattenCommonRecipe(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/internal/resources/policy/kind/image/recipe/block_latest_tag-require_digest_schema.go
+++ b/internal/resources/policy/kind/image/recipe/block_latest_tag-require_digest_schema.go
@@ -58,7 +58,7 @@ func ConstructCommonRecipe(data []interface{}) (common *policyrecipeimagemodel.V
 	common = &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CommonRecipe{}
 
 	if v, ok := commonRecipeData[AuditKey]; ok {
-		helper.SetPrimitiveValue(v, &common.Audit, AuditKey)
+		common.Audit = helper.BoolPointer(v.(bool))
 	}
 
 	return common
@@ -71,7 +71,11 @@ func FlattenCommonRecipe(common *policyrecipeimagemodel.VmwareTanzuManageV1alpha
 
 	flattenCommonRecipe := make(map[string]interface{})
 
-	flattenCommonRecipe[AuditKey] = common.Audit
+	if common.Audit == nil {
+		return data
+	}
+
+	flattenCommonRecipe[AuditKey] = *common.Audit
 
 	return []interface{}{flattenCommonRecipe}
 }

--- a/internal/resources/policy/kind/image/recipe/custom_flatten_test.go
+++ b/internal/resources/policy/kind/image/recipe/custom_flatten_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package recipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	policyrecipeimagemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image"
+	policyrecipeimagecommonmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image/common"
+)
+
+func TestFlattenCustom(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		input       *policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1Custom
+		expected    []interface{}
+	}{
+		{
+			description: "check for nil image policy custom recipe",
+			input:       nil,
+			expected:    nil,
+		},
+		{
+			description: "scenario with nil value of Audit value in custom recipe",
+			input: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1Custom{
+				Audit: nil,
+				Rules: []*policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CustomRules{
+					{
+						Hostname:      "bar",
+						ImageName:     "foo",
+						Port:          "80",
+						RequireDigest: helper.BoolPointer(true),
+						Tag: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+							Negate: helper.BoolPointer(false),
+							Value:  "test",
+						},
+					},
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					RulesKey: []interface{}{
+						map[string]interface{}{
+							HostNameKey:  "bar",
+							ImageNameKey: "foo",
+							PortKey:      "80",
+							RequireKey:   true,
+							TagKey: []interface{}{
+								map[string]interface{}{
+									NegateKey: false,
+									ValueKey:  "test",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "normal scenario with complete image policy custom recipe",
+			input: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1Custom{
+				Audit: helper.BoolPointer(true),
+				Rules: []*policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CustomRules{
+					{
+						Hostname:      "bar",
+						ImageName:     "foo",
+						Port:          "80",
+						RequireDigest: helper.BoolPointer(true),
+						Tag: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+							Negate: helper.BoolPointer(false),
+							Value:  "test",
+						},
+					},
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					AuditKey: true,
+					RulesKey: []interface{}{
+						map[string]interface{}{
+							HostNameKey:  "bar",
+							ImageNameKey: "foo",
+							PortKey:      "80",
+							RequireKey:   true,
+							TagKey: []interface{}{
+								map[string]interface{}{
+									NegateKey: false,
+									ValueKey:  "test",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			actual := FlattenCustom(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestFlattenCustomRules(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		input       *policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CustomRules
+		expected    interface{}
+	}{
+		{
+			description: "check for nil rules value of custom recipe",
+			input:       nil,
+			expected:    nil,
+		},
+		{
+			description: "normal scenario with all fields of rules spec of custom recipe",
+			input: &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1CustomRules{
+				Hostname:      "bar",
+				ImageName:     "foo",
+				Port:          "80",
+				RequireDigest: helper.BoolPointer(true),
+				Tag: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+					Negate: helper.BoolPointer(false),
+					Value:  "test",
+				},
+			},
+			expected: map[string]interface{}{
+				HostNameKey:  "bar",
+				ImageNameKey: "foo",
+				PortKey:      "80",
+				RequireKey:   true,
+				TagKey: []interface{}{
+					map[string]interface{}{
+						NegateKey: false,
+						ValueKey:  "test",
+					},
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			actual := flattenCustomRules(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/internal/resources/policy/kind/image/recipe/custom_schema.go
+++ b/internal/resources/policy/kind/image/recipe/custom_schema.go
@@ -75,7 +75,7 @@ func ConstructCustom(data []interface{}) (custom *policyrecipeimagemodel.VmwareT
 	custom = &policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1Custom{}
 
 	if v, ok := customData[AuditKey]; ok {
-		helper.SetPrimitiveValue(v, &custom.Audit, AuditKey)
+		custom.Audit = helper.BoolPointer(v.(bool))
 	}
 
 	if v, ok := customData[RulesKey]; ok {
@@ -118,7 +118,7 @@ func expandCustomRules(data interface{}) (rules *policyrecipeimagemodel.VmwareTa
 	}
 
 	if v, ok := rulesData[RequireKey]; ok {
-		helper.SetPrimitiveValue(v, &rules.RequireDigest, RequireKey)
+		rules.RequireDigest = helper.BoolPointer(v.(bool))
 	}
 
 	if v, ok := rulesData[TagKey]; ok {
@@ -137,7 +137,9 @@ func FlattenCustom(custom *policyrecipeimagemodel.VmwareTanzuManageV1alpha1Commo
 
 	flattenCustom := make(map[string]interface{})
 
-	flattenCustom[AuditKey] = custom.Audit
+	if custom.Audit != nil {
+		flattenCustom[AuditKey] = *custom.Audit
+	}
 
 	if custom.Rules != nil {
 		var rules []interface{}
@@ -162,7 +164,10 @@ func flattenCustomRules(rules *policyrecipeimagemodel.VmwareTanzuManageV1alpha1C
 	flattenRules[HostNameKey] = rules.Hostname
 	flattenRules[ImageNameKey] = rules.ImageName
 	flattenRules[PortKey] = rules.Port
-	flattenRules[RequireKey] = rules.RequireDigest
+
+	if rules.RequireDigest != nil {
+		flattenRules[RequireKey] = *rules.RequireDigest
+	}
 
 	if rules.Tag != nil {
 		flattenRules[TagKey] = flattenTag(rules.Tag)

--- a/internal/resources/policy/kind/image/recipe/tag_flatten_test.go
+++ b/internal/resources/policy/kind/image/recipe/tag_flatten_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package recipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	policyrecipeimagecommonmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image/common"
+)
+
+func TestFlattenTag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		input       *policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag
+		expected    interface{}
+	}{
+		{
+			description: "check for nil tag data",
+			input:       nil,
+			expected:    []interface{}(nil),
+		},
+		{
+			description: "scenario for nil negate value of tag",
+			input: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+				Negate: nil,
+				Value:  "test",
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					ValueKey: "test",
+				},
+			},
+		},
+		{
+			description: "normal scenario with all values of tag data",
+			input: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+				Negate: helper.BoolPointer(false),
+				Value:  "test",
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					NegateKey: false,
+					ValueKey:  "test",
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			actual := flattenTag(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/internal/resources/policy/kind/image/recipe/tag_schema.go
+++ b/internal/resources/policy/kind/image/recipe/tag_schema.go
@@ -16,6 +16,7 @@ var tag = &schema.Schema{
 	Type:        schema.TypeList,
 	Description: "Allowed image tag, wildcards are supported (for example: v1.*). No validation is performed on tag if the field is empty.",
 	Optional:    true,
+	MaxItems:    1,
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			NegateKey: {
@@ -34,12 +35,12 @@ var tag = &schema.Schema{
 	},
 }
 
-func expandTag(data interface{}) (tag *policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag) {
-	if data == nil {
+func expandTag(data []interface{}) (tag *policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag) {
+	if len(data) == 0 || data[0] == nil {
 		return tag
 	}
 
-	tagsData, ok := data.(map[string]interface{})
+	tagsData, ok := data[0].(map[string]interface{})
 	if !ok {
 		return tag
 	}
@@ -47,7 +48,7 @@ func expandTag(data interface{}) (tag *policyrecipeimagecommonmodel.VmwareTanzuM
 	tag = &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{}
 
 	if v, ok := tagsData[NegateKey]; ok {
-		helper.SetPrimitiveValue(v, &tag.Negate, NegateKey)
+		tag.Negate = helper.BoolPointer(v.(bool))
 	}
 
 	if v, ok := tagsData[ValueKey]; ok {
@@ -57,15 +58,18 @@ func expandTag(data interface{}) (tag *policyrecipeimagecommonmodel.VmwareTanzuM
 	return tag
 }
 
-func flattenTag(tag *policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag) (data interface{}) {
+func flattenTag(tag *policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag) (data []interface{}) {
 	if tag == nil {
 		return data
 	}
 
 	flattenTag := make(map[string]interface{})
 
-	flattenTag[NegateKey] = tag.Negate
+	if tag.Negate != nil {
+		flattenTag[NegateKey] = *tag.Negate
+	}
+
 	flattenTag[ValueKey] = tag.Value
 
-	return flattenTag
+	return []interface{}{flattenTag}
 }

--- a/internal/resources/policy/kind/image/resource/resource_image_registry_policy.go
+++ b/internal/resources/policy/kind/image/resource/resource_image_registry_policy.go
@@ -12,24 +12,29 @@ import (
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy"
 	policykindimage "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/kind/image"
+	policyoperations "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/operations"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/scope"
 )
 
-func ResourceImageRegistryPolicy() *schema.Resource {
+func ResourceImagePolicy() *schema.Resource {
 	return &schema.Resource{
-		Schema: imageRegistryPolicySchema,
+		CreateContext: schema.CreateContextFunc(policyoperations.ResourceOperation(policyoperations.WithResourceName(policykindimage.ResourceName), policyoperations.WithOperationType(policyoperations.Create))),
+		ReadContext:   schema.ReadContextFunc(policyoperations.ResourceOperation(policyoperations.WithResourceName(policykindimage.ResourceName), policyoperations.WithOperationType(policyoperations.Read))),
+		UpdateContext: schema.UpdateContextFunc(policyoperations.ResourceOperation(policyoperations.WithResourceName(policykindimage.ResourceName), policyoperations.WithOperationType(policyoperations.Update))),
+		DeleteContext: schema.DeleteContextFunc(policyoperations.ResourceOperation(policyoperations.WithResourceName(policykindimage.ResourceName), policyoperations.WithOperationType(policyoperations.Delete))),
+		Schema:        imagePolicySchema,
 		CustomizeDiff: customdiff.All(
-			scope.ValidateScope,
+			schema.CustomizeDiffFunc(scope.ValidateScope(policyoperations.ScopeMap[policykindimage.ResourceName])),
 			policykindimage.ValidateInput,
 			policy.ValidateSpecLabelSelectorRequirement,
 		),
 	}
 }
 
-var imageRegistryPolicySchema = map[string]*schema.Schema{
+var imagePolicySchema = map[string]*schema.Schema{
 	policy.NameKey: {
 		Type:        schema.TypeString,
-		Description: "Name of the image registry policy",
+		Description: "Name of the image policy",
 		Required:    true,
 		ForceNew:    true,
 	},

--- a/internal/resources/policy/kind/image/spec_flatten_test.go
+++ b/internal/resources/policy/kind/image/spec_flatten_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package policykindimage
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	policymodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy"
+	policyrecipeimagemodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image"
+	policyrecipeimagecommonmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/recipe/image/common"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy"
+	reciperesource "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/kind/image/recipe"
+)
+
+func TestFlattenSpec(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		input       *policymodel.VmwareTanzuManageV1alpha1CommonPolicySpec
+		expected    []interface{}
+	}{
+		{
+			description: "check for nil spec",
+			input:       nil,
+			expected:    nil,
+		},
+		{
+			description: "normal scenario with complete spec",
+			input: &policymodel.VmwareTanzuManageV1alpha1CommonPolicySpec{
+				Input: constructAllowedNameTag(),
+				NamespaceSelector: &policymodel.VmwareTanzuManageV1alpha1CommonPolicyLabelSelector{
+					MatchExpressions: []*policymodel.K8sIoApimachineryPkgApisMetaV1LabelSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: "In",
+							Values: []string{
+								"v1",
+								"v2",
+							},
+						},
+						{
+							Key:      "k2",
+							Operator: "Exists",
+							Values:   []string{},
+						},
+					},
+				},
+				Recipe: string(AllowedNameTagRecipe),
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					policy.InputKey: []interface{}{
+						map[string]interface{}{
+							reciperesource.AllowedNameTagKey: []interface{}{
+								map[string]interface{}{
+									reciperesource.AuditKey: true,
+									reciperesource.RulesKey: []interface{}{
+										map[string]interface{}{
+											reciperesource.ImageNameKey: "foo",
+											reciperesource.TagKey: []interface{}{
+												map[string]interface{}{
+													reciperesource.NegateKey: true,
+													reciperesource.ValueKey:  "test",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					policy.NamespaceSelectorKey: []interface{}{
+						map[string]interface{}{
+							policy.MatchExpressionsKey: []interface{}{
+								map[string]interface{}{
+									policy.KeyKey:      "k1",
+									policy.OperatorKey: "In",
+									policy.ValuesKey: []string{
+										"v1",
+										"v2",
+									},
+								},
+								map[string]interface{}{
+									policy.KeyKey:      "k2",
+									policy.OperatorKey: "Exists",
+									policy.ValuesKey:   []string{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, each := range cases {
+		test := each
+		t.Run(test.description, func(t *testing.T) {
+			actual := FlattenSpec(test.input)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func constructAllowedNameTag() (allowedNameTagRecipeInput map[string]interface{}) {
+	allowedNameTagInput := policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTag{
+		Audit: helper.BoolPointer(true),
+		Rules: []*policyrecipeimagemodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1AllowedNameTagRules{
+			{
+				ImageName: "foo",
+				Tag: &policyrecipeimagecommonmodel.VmwareTanzuManageV1alpha1CommonPolicySpecImageV1RulesTag{
+					Negate: helper.BoolPointer(true),
+					Value:  "test",
+				},
+			},
+		},
+	}
+
+	binary, err := allowedNameTagInput.MarshalBinary()
+	if err != nil {
+		return nil
+	}
+
+	err = json.Unmarshal(binary, &allowedNameTagRecipeInput)
+	if err != nil {
+		return nil
+	}
+
+	return allowedNameTagRecipeInput
+}

--- a/internal/resources/policy/kind/security/resource/resource_security_policy.go
+++ b/internal/resources/policy/kind/security/resource/resource_security_policy.go
@@ -24,7 +24,7 @@ func ResourceSecurityPolicy() *schema.Resource {
 		DeleteContext: schema.DeleteContextFunc(policyoperations.ResourceOperation(policyoperations.WithResourceName(policykindsecurity.ResourceName), policyoperations.WithOperationType(policyoperations.Delete))),
 		Schema:        securityPolicySchema,
 		CustomizeDiff: customdiff.All(
-			scope.ValidateScope,
+			schema.CustomizeDiffFunc(scope.ValidateScope(policyoperations.ScopeMap[policykindsecurity.ResourceName])),
 			policykindsecurity.ValidateInput,
 			policy.ValidateSpecLabelSelectorRequirement,
 		),

--- a/internal/resources/policy/kind/security/resource/resource_security_policy_test.go
+++ b/internal/resources/policy/kind/security/resource/resource_security_policy_test.go
@@ -26,6 +26,7 @@ import (
 	policyorganizationmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/policy/organization"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy"
 	policykindsecurity "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/kind/security"
+	policyoperations "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/operations"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/policy/scope"
 	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
 )
@@ -168,7 +169,7 @@ func TestAcceptanceForSecurityPolicyResource(t *testing.T) {
 }
 
 func (testConfig *testAcceptanceConfig) getTestSecurityPolicyResourceBasicConfigValue(scope scope.Scope, recipe policykindsecurity.Recipe) string {
-	helperBlock, scopeBlock := testConfig.ScopeHelperResources.GetTestPolicyResourceHelperAndScope(scope)
+	helperBlock, scopeBlock := testConfig.ScopeHelperResources.GetTestPolicyResourceHelperAndScope(scope, policyoperations.ScopeMap[testConfig.SecurityPolicyResource])
 	inputBlock := testConfig.getTestSecurityPolicyResourceInput(recipe)
 
 	return fmt.Sprintf(`
@@ -371,7 +372,7 @@ func (testConfig *testAcceptanceConfig) checkSecurityPolicyResourceAttributes(sc
 	case scope.OrganizationScope:
 		check = append(check, resource.TestCheckResourceAttr(testConfig.SecurityPolicyResourceName, "scope.0.organization.0.organization", testConfig.ScopeHelperResources.OrgID))
 	case scope.UnknownScope:
-		log.Printf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scope.ScopesAllowed[:], `, `))
+		log.Printf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(policyoperations.ScopeMap[testConfig.SecurityPolicyResource], `, `))
 	}
 
 	check = append(check, policy.MetaResourceAttributeCheck(testConfig.SecurityPolicyResourceName)...)
@@ -452,7 +453,7 @@ func (testConfig *testAcceptanceConfig) verifySecurityPolicyResourceCreation(sco
 				return errors.Wrapf(err, "organization scoped security policy resource is empty, resource: %s", testConfig.SecurityPolicyResourceName)
 			}
 		case scope.UnknownScope:
-			return errors.Errorf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scope.ScopesAllowed[:], `, `))
+			return errors.Errorf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(policyoperations.ScopeMap[testConfig.SecurityPolicyResource], `, `))
 		}
 
 		return nil

--- a/internal/resources/policy/operations/create.go
+++ b/internal/resources/policy/operations/create.go
@@ -119,7 +119,7 @@ func ResourcePolicyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 			UID = policyResponse.Policy.Meta.UID
 		}
 	case scope.UnknownScope:
-		return diag.Errorf("no valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scope.ScopesAllowed[:], `, `))
+		return diag.Errorf("no valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(ScopeMap[rn], `, `))
 	}
 
 	// always run

--- a/internal/resources/policy/operations/delete.go
+++ b/internal/resources/policy/operations/delete.go
@@ -58,7 +58,7 @@ func ResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m interfa
 			}
 		}
 	case scope.UnknownScope:
-		return diag.Errorf("no valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scope.ScopesAllowed[:], `, `))
+		return diag.Errorf("no valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(ScopeMap[rn], `, `))
 	}
 
 	// d.SetId("") is automatically called assuming delete returns no errors, but

--- a/internal/resources/policy/operations/update.go
+++ b/internal/resources/policy/operations/update.go
@@ -127,7 +127,7 @@ func ResourcePolicyInPlaceUpdate(ctx context.Context, d *schema.ResourceData, m 
 			}
 		}
 	case scope.UnknownScope:
-		return diag.Errorf("no valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scope.ScopesAllowed[:], `, `))
+		return diag.Errorf("no valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(ScopeMap[rn], `, `))
 	}
 
 	log.Printf("[INFO] %s policy update successful", rn)

--- a/internal/resources/policy/scope/constants.go
+++ b/internal/resources/policy/scope/constants.go
@@ -14,10 +14,10 @@ const (
 	WorkspaceNameKey         = "workspace"
 	OrganizationIDKey        = "organization"
 	ScopeKey                 = "scope"
-	clusterKey               = "cluster"
-	clusterGroupKey          = "cluster_group"
-	workspaceKey             = "workspace"
-	organizationKey          = "organization"
+	ClusterKey               = "cluster"
+	ClusterGroupKey          = "cluster_group"
+	WorkspaceKey             = "workspace"
+	OrganizationKey          = "organization"
 )
 
 // Allowed scopes.

--- a/internal/resources/policy/scope/scope_flatten_test.go
+++ b/internal/resources/policy/scope/scope_flatten_test.go
@@ -22,6 +22,7 @@ func TestFlattenScope(t *testing.T) {
 	cases := []struct {
 		description  string
 		input        *ScopedFullname
+		allowedScope []string
 		expectedData []interface{}
 		expectedName string
 	}{
@@ -44,7 +45,7 @@ func TestFlattenScope(t *testing.T) {
 			},
 			expectedData: []interface{}{
 				map[string]interface{}{
-					clusterKey: []interface{}{
+					ClusterKey: []interface{}{
 						map[string]interface{}{
 							ManagementClusterNameKey: "m",
 							ClusterNameKey:           "c",
@@ -66,7 +67,7 @@ func TestFlattenScope(t *testing.T) {
 			},
 			expectedData: []interface{}{
 				map[string]interface{}{
-					clusterGroupKey: []interface{}{
+					ClusterGroupKey: []interface{}{
 						map[string]interface{}{
 							ClusterGroupNameKey: "c",
 						},
@@ -86,7 +87,7 @@ func TestFlattenScope(t *testing.T) {
 			},
 			expectedData: []interface{}{
 				map[string]interface{}{
-					workspaceKey: []interface{}{
+					WorkspaceKey: []interface{}{
 						map[string]interface{}{
 							WorkspaceNameKey: "w",
 						},
@@ -106,7 +107,7 @@ func TestFlattenScope(t *testing.T) {
 			},
 			expectedData: []interface{}{
 				map[string]interface{}{
-					organizationKey: []interface{}{
+					OrganizationKey: []interface{}{
 						map[string]interface{}{
 							OrganizationIDKey: "o",
 						},
@@ -120,7 +121,7 @@ func TestFlattenScope(t *testing.T) {
 	for _, each := range cases {
 		test := each
 		t.Run(test.description, func(t *testing.T) {
-			actualData, actualName := FlattenScope(test.input)
+			actualData, actualName := FlattenScope(test.input, test.allowedScope)
 			require.Equal(t, test.expectedData, actualData)
 			require.Equal(t, test.expectedName, actualName)
 		})

--- a/internal/resources/policy/test_helper.go
+++ b/internal/resources/policy/test_helper.go
@@ -116,7 +116,7 @@ resource "%s" "%s" {
 }
 
 // GetTestPolicyResourceHelperAndScope builds the helper resource and scope blocks for policy resource based on a scope type.
-func (shr *ScopeHelperResources) GetTestPolicyResourceHelperAndScope(scopeType scope.Scope) (string, string) {
+func (shr *ScopeHelperResources) GetTestPolicyResourceHelperAndScope(scopeType scope.Scope, scopesAllowed []string) (string, string) {
 	var (
 		helperBlock string
 		scopeBlock  string
@@ -153,7 +153,7 @@ func (shr *ScopeHelperResources) GetTestPolicyResourceHelperAndScope(scopeType s
 	}
 	`, shr.OrgID)
 	case scope.UnknownScope:
-		log.Printf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scope.ScopesAllowed[:], `, `))
+		log.Printf("[ERROR]: No valid scope type block found: minimum one valid scope type block is required among: %v. Please check the schema.", strings.Join(scopesAllowed, `, `))
 	}
 
 	return helperBlock, scopeBlock


### PR DESCRIPTION
Signed-off-by: Vasundhara Shukla <vasundharas@vmware.com>

1. **What this PR does / why we need it**:

- Scope refactoring
- Resource implementation
- Flatten tests for image policy schemas



<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->