### PR TITLE
Force detach the clusters when the cluster is not connected to TMC

### DIFF
--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -90,8 +90,8 @@ func TestRetryUntilTimeout(t *testing.T) {
 		return true, nil
 	}
 
-	retries, err := RetryUntilTimeout(testFun, 1*time.Second, 6*time.Second)
+	retries, err := RetryUntilTimeout(testFun, 1*time.Second, 2*time.Second)
 
 	require.NoError(t, err)
-	require.Equal(t, 4, retries)
+	require.Equal(t, 2, retries)
 }

--- a/internal/helper/retry.go
+++ b/internal/helper/retry.go
@@ -42,19 +42,18 @@ func RetryUntilTimeout(f Retryable, interval time.Duration, timeout time.Duratio
 
 	timeElapsedInSeconds := 0
 
-	retries := 1
+	retries := 0
 
 	for timeElapsedInSeconds < int(timeout.Seconds()) {
+		retries++
 		retry, err = f()
 		if !retry {
 			break
 		}
 
-		presentBackOffInterval := (retries * int(interval.Seconds()))
-		time.Sleep(time.Duration(presentBackOffInterval) * time.Second)
+		time.Sleep(interval)
 
-		timeElapsedInSeconds += presentBackOffInterval
-		retries++
+		timeElapsedInSeconds += int(interval.Seconds())
 	}
 
 	return retries, err

--- a/internal/resources/cluster/data_source_cluster.go
+++ b/internal/resources/cluster/data_source_cluster.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -52,8 +53,8 @@ func dataSourceTMCClusterRead(ctx context.Context, d *schema.ResourceData, m int
 
 		d.SetId(resp.Cluster.Meta.UID)
 
-		if clustermodel.NewVmwareTanzuManageV1alpha1ClusterPhase(clustermodel.VmwareTanzuManageV1alpha1ClusterPhaseREADY) != resp.Cluster.Status.Phase {
-			log.Printf("[DEBUG] waiting for cluster(%s) to be in READY phase", constructFullname(d).ToString())
+		if !strings.EqualFold(string(clustermodel.VmwareTanzuManageV1alpha1ClusterPhaseREADY), string(*resp.Cluster.Status.Phase)) {
+			log.Printf("[DEBUG] waiting for cluster(%s) to be in %v phase, present phase:%v", constructFullname(d).ToString(), clustermodel.VmwareTanzuManageV1alpha1ClusterPhaseREADY, *resp.Cluster.Status.Phase)
 			return true, nil
 		}
 

--- a/internal/resources/credential/credential.go
+++ b/internal/resources/credential/credential.go
@@ -73,6 +73,7 @@ var dataSpec = &schema.Schema{
 	Optional:    true,
 	MaxItems:    1,
 	Description: "Holds credentials sensitive data",
+	Sensitive:   true,
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			genericCredentialKey: {


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Force detach the clusters when the cluster is not connected to TMC

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**

The changes has been validated manually by attaching and detaching the kind cluster. 
The SD ticket scenario was mimicked and the changes worked as expected 

4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->