### PR TITLE
refresh auth token silently when token expires

### DIFF
--- a/internal/authctx/authentication.go
+++ b/internal/authctx/authentication.go
@@ -134,3 +134,10 @@ func getUserAuthCtx(config *TanzuContext) (map[string]string, error) {
 
 	return md, nil
 }
+
+func RefreshUserAuthCtx(config *TanzuContext) {
+	md, _ := getUserAuthCtx(config)
+	for key, value := range md {
+		config.TMCConnection.Headers.Set(key, value)
+	}
+}

--- a/internal/client/errors/errors.go
+++ b/internal/client/errors/errors.go
@@ -41,6 +41,24 @@ func IsNotFoundError(err error) bool {
 	return false
 }
 
+func IsUnauthorizedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	convertedError, ok := err.(ClientErrors)
+	if !ok {
+		return strings.Contains(err.Error(), fmt.Sprintf("%d", http.StatusUnauthorized)) &&
+			strings.Contains(err.Error(), http.StatusText(http.StatusUnauthorized))
+	}
+
+	if convertedError.httpCode == http.StatusUnauthorized {
+		return true
+	}
+
+	return false
+}
+
 func (e ClientErrors) Error() string {
 	if e.err == nil {
 		return ""


### PR DESCRIPTION
1. **What this PR does / why we need it**:
Refresh auth token in the background when it expires.
2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #OLYMP-36711


3. **Additional information**
![Screen Shot 2023-02-28 at 5 43 13 PM](https://user-images.githubusercontent.com/36141526/222023487-0ad8adb0-3916-4d18-8f23-aedfc38f8cfd.png)

4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"

-->
