### PR TITLE
Making control plane endpoint optional for TKG vSphere cluster

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -549,13 +549,13 @@ Required:
 
 Required:
 
-- `control_plane_end_point` (String) ControlPlaneEndpoint specifies the control plane virtual IP address. The value should be unique for every create request, else cluster creation shall fail
 - `pods` (Block List, Min: 1) Pod CIDR for Kubernetes pods defaults to 192.168.0.0/16 (see [below for nested schema](#nestedblock--spec--tkg_vsphere--settings--network--pods))
 - `services` (Block List, Min: 1) Service CIDR for kubernetes services defaults to 10.96.0.0/12 (see [below for nested schema](#nestedblock--spec--tkg_vsphere--settings--network--services))
 
 Optional:
 
 - `api_server_port` (Number) APIServerPort specifies the port address for the cluster that defaults to 6443.
+- `control_plane_end_point` (String) ControlPlaneEndpoint specifies the control plane virtual IP address. The value should be unique for every create request, else cluster creation shall fail
 
 <a id="nestedblock--spec--tkg_vsphere--settings--network--pods"></a>
 ### Nested Schema for `spec.tkg_vsphere.settings.network.pods`

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -915,13 +915,13 @@ Required:
 
 Required:
 
-- `control_plane_end_point` (String) ControlPlaneEndpoint specifies the control plane virtual IP address. The value should be unique for every create request, else cluster creation shall fail
 - `pods` (Block List, Min: 1) Pod CIDR for Kubernetes pods defaults to 192.168.0.0/16 (see [below for nested schema](#nestedblock--spec--tkg_vsphere--settings--network--pods))
 - `services` (Block List, Min: 1) Service CIDR for kubernetes services defaults to 10.96.0.0/12 (see [below for nested schema](#nestedblock--spec--tkg_vsphere--settings--network--services))
 
 Optional:
 
 - `api_server_port` (Number) APIServerPort specifies the port address for the cluster that defaults to 6443.
+- `control_plane_end_point` (String) ControlPlaneEndpoint specifies the control plane virtual IP address. The value should be unique for every create request, else cluster creation shall fail
 
 <a id="nestedblock--spec--tkg_vsphere--settings--network--pods"></a>
 ### Nested Schema for `spec.tkg_vsphere.settings.network.pods`

--- a/internal/resources/cluster/tkgvsphere/resource_tkgvsphere.go
+++ b/internal/resources/cluster/tkgvsphere/resource_tkgvsphere.go
@@ -179,7 +179,7 @@ var tkgVsphereNetwork = &schema.Schema{
 			controlPlaneEndPointKey: {
 				Type:        schema.TypeString,
 				Description: "ControlPlaneEndpoint specifies the control plane virtual IP address. The value should be unique for every create request, else cluster creation shall fail",
-				Required:    true,
+				Optional:    true,
 			},
 			podsKey: {
 				Type:        schema.TypeList,


### PR DESCRIPTION
1. **What this PR does / why we need it**:
vSphere controlplane endpoint ip should not be required when enabled AVI when you create a legacy cluster on TKGm. Making it optional.


<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->