### PR TITLE
Handle case of not found cluster entry in Cluster data source

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -42,28 +42,28 @@ You must also have the appropriate permissions:
 ## Example Usage
 
 ```terraform
-# Read Tanzu Mission Control cluster : fetch cluster details
+# Read Tanzu Mission Control cluster : fetch cluster details for an already attached cluster
 data "tanzu-mission-control_cluster" "ready_only_attach_cluster_view" {
   management_cluster_name = "attached"       # Default: attached
   provisioner_name        = "attached"       # Default: attached
   name                    = "terraform-test" # Required
 }
 
-# Read Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster : fetch TKGs cluster details
+# Read Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster : fetch cluster details for already present TKGs cluster
 data "tanzu-mission-control_cluster" "read_tkgs_cluster" {
   management_cluster_name = "test-tkgs"
   provisioner_name        = "test-gc-e2e-demo-ns"
   name                    = "tkgs-workload"
 }
 
-# Read Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster : fetch TKG vSphere cluster details
+# Read Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster : fetch cluster details for already present TKG vSphere cluster
 data "tanzu-mission-control_cluster" "read_tkg_vsphere_cluster" {
   management_cluster_name = "tkgm-vsphere"
   provisioner_name        = "default"
   name                    = "tkgm-workload"
 }
 
-# Read Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster : fetch TKG AWS cluster details
+# Read Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster : fetch cluster details for already present TKG AWS cluster
 data "tanzu-mission-control_cluster" "read_tkg_aws_cluster" {
   management_cluster_name = "tkgm-aws"
   provisioner_name        = "default"

--- a/docs/guides/tanzu-mission-control_cluster.md
+++ b/docs/guides/tanzu-mission-control_cluster.md
@@ -42,11 +42,11 @@ This example assumes that you have already registered a Tanzu Kubernetes Grid Se
 // Tanzu Mission Control Cluster Type: Tanzu Kubernetes Grid Service workload.
 // Operations supported : Read, Create, Update & Delete (except nodepools)
 
-// Read Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster : fetch cluster details
+// Read Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster : fetch cluster details for already present TKGs cluster
 data "tanzu-mission-control_cluster" "ready_only_cluster_view" {
-  management_cluster_name = "<management-cluster>" // Required
-  provisioner_name        = "<prov-name>"          // Required
-  name                    = "<cluster-name>"       // Required
+  management_cluster_name = "<existing-management-cluster>" // Required
+  provisioner_name        = "<existing-prov-name>"          // Required
+  name                    = "<existing-cluster-name>"       // Required
 }
 
 # Create Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster entry
@@ -163,11 +163,11 @@ This example assumes that you have already registered a Tanzu Kubernetes Grid ma
 // Tanzu Mission Control Cluster Type: Tanzu Kubernetes Grid vSphere workload.
 // Operations supported : Read, Create, Update & Delete (except nodepools)
 
-// Read Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster : fetch cluster details
+// Read Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster : fetch cluster details for already present TKG vSphere cluster
 data "tanzu-mission-control_cluster" "ready_only_cluster_view" {
-  management_cluster_name = "<management-cluster>" // Required
-  provisioner_name        = "<prov-name>"          // Required
-  name                    = "<cluster-name>"       // Required
+  management_cluster_name = "<existing-management-cluster>" // Required
+  provisioner_name        = "<existing-prov-name>"          // Required
+  name                    = "<existing-cluster-name>"       // Required
 }
 
 // Create Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster entry
@@ -300,11 +300,11 @@ This example assumes that you have already registered a Tanzu Kubernetes Grid ma
 // Tanzu Mission Control Cluster Type: Tanzu Kubernetes Grid AWS workload.
 // Operations supported : Read, Create, Update & Delete (except nodepools)
 
-// Read Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster : fetch cluster details
+// Read Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster : fetch cluster details for already present TKG AWS cluster
 data "tanzu-mission-control_cluster" "ready_only_cluster_view" {
-  management_cluster_name = "<management-cluster>" // Required
-  provisioner_name        = "<prov-name>"          // Required
-  name                    = "<cluster-name>"       // Required
+  management_cluster_name = "<existing-management-cluster>" // Required
+  provisioner_name        = "<existing-prov-name>"          // Required
+  name                    = "<existing-cluster-name>"       // Required
 }
 
 // Create Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster entry

--- a/examples/data-sources/cluster/data-source.tf
+++ b/examples/data-sources/cluster/data-source.tf
@@ -1,25 +1,25 @@
-# Read Tanzu Mission Control cluster : fetch cluster details
+# Read Tanzu Mission Control cluster : fetch cluster details for an already attached cluster
 data "tanzu-mission-control_cluster" "ready_only_attach_cluster_view" {
   management_cluster_name = "attached"       # Default: attached
   provisioner_name        = "attached"       # Default: attached
   name                    = "terraform-test" # Required
 }
 
-# Read Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster : fetch TKGs cluster details
+# Read Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster : fetch cluster details for already present TKGs cluster
 data "tanzu-mission-control_cluster" "read_tkgs_cluster" {
   management_cluster_name = "test-tkgs"
   provisioner_name        = "test-gc-e2e-demo-ns"
   name                    = "tkgs-workload"
 }
 
-# Read Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster : fetch TKG vSphere cluster details
+# Read Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster : fetch cluster details for already present TKG vSphere cluster
 data "tanzu-mission-control_cluster" "read_tkg_vsphere_cluster" {
   management_cluster_name = "tkgm-vsphere"
   provisioner_name        = "default"
   name                    = "tkgm-workload"
 }
 
-# Read Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster : fetch TKG AWS cluster details
+# Read Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster : fetch cluster details for already present TKG AWS cluster
 data "tanzu-mission-control_cluster" "read_tkg_aws_cluster" {
   management_cluster_name = "tkgm-aws"
   provisioner_name        = "default"

--- a/internal/models/policy/recipe/quota/custom.go
+++ b/internal/models/policy/recipe/quota/custom.go
@@ -10,7 +10,7 @@ import "github.com/go-openapi/swag"
 
 // VmwareTanzuManageV1alpha1CommonPolicySpecQuotaV1Custom Input schema for namespace quota policy custom recipe version v1
 //
-// The input schema for namespace quota policy custom recipe version v1
+// # The input schema for namespace quota policy custom recipe version v1
 //
 // swagger:model VmwareTanzuManageV1alpha1CommonPolicySpecQuotaV1Custom
 type VmwareTanzuManageV1alpha1CommonPolicySpecQuotaV1Custom struct {

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -38,7 +38,7 @@ type (
 
 func ResourceTMCCluster() *schema.Resource {
 	return &schema.Resource{
-		ReadContext:   dataSourceTMCClusterRead,
+		ReadContext:   dataSourceClusterRead,
 		CreateContext: resourceClusterCreate,
 		UpdateContext: resourceClusterInPlaceUpdate,
 		DeleteContext: resourceClusterDelete,
@@ -353,7 +353,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, m interf
 		log.Printf("[INFO] Cluster attach successful. Tanzu Mission Control resources applied to the cluster(%s) successfully", constructFullname(d).ToString())
 	}
 
-	return append(diags, dataSourceTMCClusterRead(context.WithValue(ctx, contextMethodKey{}, "create"), d, m)...)
+	return append(diags, dataSourceClusterRead(context.WithValue(ctx, contextMethodKey{}, "create"), d, m)...)
 }
 
 type (
@@ -564,5 +564,5 @@ func resourceClusterInPlaceUpdate(ctx context.Context, d *schema.ResourceData, m
 		log.Printf("[INFO] cluster update successful")
 	}
 
-	return dataSourceTMCClusterRead(ctx, d, m)
+	return dataSourceClusterRead(ctx, d, m)
 }

--- a/resource_templates/cluster_attach.tf
+++ b/resource_templates/cluster_attach.tf
@@ -1,11 +1,11 @@
 // Tanzu Mission Control Cluster Type: Attach. Bring your own k8s cluster and attach it to Tanzu Mission Control.
 // Operations supported : Read, Create, Update & Delete
 
-// Read Tanzu Mission Control cluster : fetch cluster details
+// Read Tanzu Mission Control cluster : fetch cluster details for an already attached cluster
 data "tanzu-mission-control_cluster" "ready_only_cluster_view" {
-  management_cluster_name = "<management-cluster>" // Default: attached
-  provisioner_name        = "<prov-name>"          // Default: attached
-  name                    = "<cluster-name>"       // Required
+  management_cluster_name = "<existing-management-cluster>" // Default: attached
+  provisioner_name        = "<existing-prov-name>"          // Default: attached
+  name                    = "<existing-cluster-name>"       // Required
 }
 
 // Create Tanzu Mission Control attach cluster entry

--- a/resource_templates/cluster_node_pool.tf
+++ b/resource_templates/cluster_node_pool.tf
@@ -3,10 +3,10 @@
 
 # Read Tanzu Mission Control cluster nodepool : fetch cluster nodepool details
 data "tanzu-mission-control_cluster_node_pool" "read_node_pool" {
-  management_cluster_name = "<management-cluster>" // Default: attached
-  provisioner_name        = "<prov-name>"          // Default: attached
-  cluster_name            = "<cluster_name>"       // Required
-  name                    = "<node_pool-name>"     // Required
+  management_cluster_name = "<existing-management-cluster>" // Default: attached
+  provisioner_name        = "<existing-prov-name>"          // Default: attached
+  cluster_name            = "<existing-cluster_name>"       // Required
+  name                    = "<existing-node_pool-name>"     // Required
 }
 
 # Create Tanzu Mission Control cluster nodepool entry

--- a/resource_templates/cluster_tkg_aws.tf
+++ b/resource_templates/cluster_tkg_aws.tf
@@ -1,11 +1,11 @@
 // Tanzu Mission Control Cluster Type: Tanzu Kubernetes Grid AWS workload.
 // Operations supported : Read, Create, Update & Delete (except nodepools)
 
-// Read Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster : fetch cluster details
+// Read Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster : fetch cluster details for already present TKG AWS cluster
 data "tanzu-mission-control_cluster" "ready_only_cluster_view" {
-  management_cluster_name = "<management-cluster>" // Required
-  provisioner_name        = "<prov-name>"          // Required
-  name                    = "<cluster-name>"       // Required
+  management_cluster_name = "<existing-management-cluster>" // Required
+  provisioner_name        = "<existing-prov-name>"          // Required
+  name                    = "<existing-cluster-name>"       // Required
 }
 
 // Create Tanzu Mission Control Tanzu Kubernetes Grid AWS workload cluster entry

--- a/resource_templates/cluster_tkg_vsphere.tf
+++ b/resource_templates/cluster_tkg_vsphere.tf
@@ -1,11 +1,11 @@
 // Tanzu Mission Control Cluster Type: Tanzu Kubernetes Grid vSphere workload.
 // Operations supported : Read, Create, Update & Delete (except nodepools)
 
-// Read Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster : fetch cluster details
+// Read Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster : fetch cluster details for already present TKG vSphere cluster
 data "tanzu-mission-control_cluster" "ready_only_cluster_view" {
-  management_cluster_name = "<management-cluster>" // Required
-  provisioner_name        = "<prov-name>"          // Required
-  name                    = "<cluster-name>"       // Required
+  management_cluster_name = "<existing-management-cluster>" // Required
+  provisioner_name        = "<existing-prov-name>"          // Required
+  name                    = "<existing-cluster-name>"       // Required
 }
 
 // Create Tanzu Mission Control Tanzu Kubernetes Grid vSphere workload cluster entry

--- a/resource_templates/cluster_tkgs.tf
+++ b/resource_templates/cluster_tkgs.tf
@@ -1,11 +1,11 @@
 // Tanzu Mission Control Cluster Type: Tanzu Kubernetes Grid Service workload.
 // Operations supported : Read, Create, Update & Delete (except nodepools)
 
-// Read Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster : fetch cluster details
+// Read Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster : fetch cluster details for already present TKGs cluster
 data "tanzu-mission-control_cluster" "ready_only_cluster_view" {
-  management_cluster_name = "<management-cluster>" // Required
-  provisioner_name        = "<prov-name>"          // Required
-  name                    = "<cluster-name>"       // Required
+  management_cluster_name = "<existing-management-cluster>" // Required
+  provisioner_name        = "<existing-prov-name>"          // Required
+  name                    = "<existing-cluster-name>"       // Required
 }
 
 # Create Tanzu Mission Control Tanzu Kubernetes Grid Service workload cluster entry


### PR DESCRIPTION
1. **What this PR does / why we need it**:
The provider behaved abruptly and crashed when the data source was called on a non-existent cluster, to avoid the crush the error needed to be handled.

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**
The PR throws the right error for an invalid get call and avoids provider crash. Moreover, the documentation has been changed to show that data source needs to be called for a valid (existing) Tanzu Mission Control resource.

4. **Error handling proof:**

<img width="1734" alt="Screenshot 2023-03-09 at 1 52 53 PM" src="https://user-images.githubusercontent.com/32017029/223962875-81df6d65-138d-4cf9-894c-392118fcf93e.png">



<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->