### PR TITLE
added support for EKS cluster import

### DIFF
--- a/internal/client/ekscluster/cluster_resource.go
+++ b/internal/client/ekscluster/cluster_resource.go
@@ -6,8 +6,13 @@ SPDX-License-Identifier: MPL-2.0
 package ekscluster
 
 import (
+	"fmt"
+	"net/http"
 	"net/url"
 
+	"github.com/pkg/errors"
+
+	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
 	eksmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/ekscluster"
@@ -39,6 +44,8 @@ type ClientService interface {
 	EksClusterResourceServiceDelete(fn *eksmodel.VmwareTanzuManageV1alpha1EksclusterFullName, force string) error
 
 	EksClusterResourceServiceGet(fn *eksmodel.VmwareTanzuManageV1alpha1EksclusterFullName) (*eksmodel.VmwareTanzuManageV1alpha1EksclusterGetEksClusterResponse, error)
+
+	EksClusterResourceServiceGetByID(id string) (*eksmodel.VmwareTanzuManageV1alpha1EksclusterGetEksClusterResponse, error)
 
 	EksClusterResourceServiceUpdate(request *eksmodel.VmwareTanzuManageV1alpha1EksclusterCreateUpdateEksClusterRequest) (*eksmodel.VmwareTanzuManageV1alpha1EksclusterCreateUpdateEksClusterResponse, error)
 }
@@ -92,6 +99,36 @@ func (c *Client) EksClusterResourceServiceGet(fn *eksmodel.VmwareTanzuManageV1al
 	err := c.Get(requestURL, clusterResponse)
 
 	return clusterResponse, err
+}
+
+/*
+EksClusterResourceServiceGetByID gets an eks cluster by its ID.
+*/
+func (c *Client) EksClusterResourceServiceGetByID(id string) (*eksmodel.VmwareTanzuManageV1alpha1EksclusterGetEksClusterResponse, error) {
+	queryParams := url.Values{
+		"query": []string{fmt.Sprintf("uid=\"%s\"", id)},
+	}
+
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup).AppendQueryParams(queryParams).String()
+	clusterListResponse := &eksmodel.VmwareTanzuManageV1alpha1EksclusterListEksClustersResponse{}
+
+	err := c.Get(requestURL, clusterListResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(clusterListResponse.EksClusters) == 0 {
+		return nil, clienterrors.ErrorWithHTTPCode(http.StatusNotFound, errors.New("cluster list by ID was empty"))
+	}
+
+	if len(clusterListResponse.EksClusters) > 1 {
+		return nil, clienterrors.ErrorWithHTTPCode(http.StatusExpectationFailed, errors.New("cluster list by ID returned more than one cluster"))
+	}
+
+	clusterResponse := &eksmodel.VmwareTanzuManageV1alpha1EksclusterGetEksClusterResponse{}
+	clusterResponse.EksCluster = clusterListResponse.EksClusters[0]
+
+	return clusterResponse, nil
 }
 
 /*

--- a/internal/models/ekscluster/method_list.go
+++ b/internal/models/ekscluster/method_list.go
@@ -1,0 +1,43 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package models
+
+import (
+	"github.com/go-openapi/swag"
+)
+
+// VmwareTanzuManageV1alpha1EksclusterListEksClustersResponse Response from listing EksClusters.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.ekscluster.ListEksClustersResponse
+type VmwareTanzuManageV1alpha1EksclusterListEksClustersResponse struct {
+
+	// List of eksclusters.
+	EksClusters []*VmwareTanzuManageV1alpha1EksclusterEksCluster `json:"eksClusters"`
+
+	// Total count.
+	TotalCount string `json:"totalCount,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1EksclusterListEksClustersResponse) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1EksclusterListEksClustersResponse) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1EksclusterListEksClustersResponse
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/resources/ekscluster/helpers.go
+++ b/internal/resources/ekscluster/helpers.go
@@ -15,13 +15,13 @@ func nodepoolSpecEqual(spec1 *eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepo
 		spec1.CapacityType == spec2.CapacityType &&
 		setEquality(spec1.InstanceTypes, spec2.InstanceTypes) &&
 		structEqual(spec1.LaunchTemplate, spec2.LaunchTemplate) &&
-		reflect.DeepEqual(spec1.NodeLabels, spec2.NodeLabels) &&
+		mapEqual(spec1.NodeLabels, spec2.NodeLabels) &&
 		nodepoolRemoteAccessEqual(spec1.RemoteAccess, spec2.RemoteAccess) &&
 		spec1.RoleArn == spec2.RoleArn &&
 		spec1.RootDiskSize == spec2.RootDiskSize &&
 		structEqual(spec1.ScalingConfig, spec2.ScalingConfig) &&
 		setEquality(spec1.SubnetIds, spec2.SubnetIds) &&
-		reflect.DeepEqual(spec1.Tags, spec2.Tags) &&
+		mapEqual(spec1.Tags, spec2.Tags) &&
 		nodepoolTaintsEqual(spec1.Taints, spec2.Taints) &&
 		structEqual(spec1.UpdateConfig, spec2.UpdateConfig)
 }
@@ -44,7 +44,7 @@ func clusterConfigEqual(config1, config2 *eksmodel.VmwareTanzuManageV1alpha1Eksc
 	return structEqual(config1.KubernetesNetworkConfig, config2.KubernetesNetworkConfig) &&
 		structEqual(config1.Logging, config2.Logging) &&
 		config1.RoleArn == config2.RoleArn &&
-		reflect.DeepEqual(config1.Tags, config2.Tags) &&
+		mapEqual(config1.Tags, config2.Tags) &&
 		config1.Version == config2.Version &&
 		clusterVPCConfigEqual(config1.Vpc, config2.Vpc)
 }
@@ -72,6 +72,19 @@ func structEqual[T any](a, b *T) bool {
 
 	if b == nil {
 		b = new(T)
+	}
+
+	return reflect.DeepEqual(a, b)
+}
+
+// mapEqual handles the cases where one map is nil and the other one is empty.
+func mapEqual[K comparable, V any](a, b map[K]V) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	if len(a) == 0 {
+		return true
 	}
 
 	return reflect.DeepEqual(a, b)


### PR DESCRIPTION
1. **What this PR does / why we need it**:

This PR adds importing an existing EKS cluster (in TMC) into Terraform's state for further management under Terraform.

2. **Which issue(s) this PR fixes**


        Fixes # OLYMP-38955


3. **Additional information**


4. **Special notes for your reviewer**

Screenshot of successful test run
<img width="953" alt="image" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/8471682/59b5ec6b-a923-484f-b28c-f632ffd7242e">

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->