### PR TITLE
Add Mock Acceptance tests for kubernetes secret resource 

### DIFF
--- a/internal/resources/kubernetessecret/resource_secret_mock_test.go
+++ b/internal/resources/kubernetessecret/resource_secret_mock_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package kubernetessecret
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-test/deep"
+	"github.com/jarcoal/httpmock"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	secretmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/kubernetessecret/cluster"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/status"
+)
+
+const (
+	https              = "https:/"
+	apiVersionAndGroup = "v1alpha1/clusters"
+	apiSubGroup        = "namespaces"
+	apiKind            = "secrets"
+	exportAPIKind      = "secretexports"
+)
+
+func getMockSpec() secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecretSpec {
+	return secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecretSpec{
+		SecretType: secretmodel.NewVmwareTanzuManageV1alpha1ClusterNamespaceSecretType(secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecretTypeSECRETTYPEDOCKERCONFIGJSON),
+		Data: map[string]strfmt.Base64{
+			".dockerconfigjson": []byte(`{"auths":{"someregistryurl":{"auth":"","password":"","username":"someusername"}}}`),
+		},
+	}
+}
+
+func bodyInspectingResponder(t *testing.T, expectedContent interface{}, successResponse int, successResponseBody interface{}) httpmock.Responder {
+	return func(r *http.Request) (*http.Response, error) {
+		successFunc := func() (*http.Response, error) {
+			return httpmock.NewJsonResponse(successResponse, successResponseBody)
+		}
+
+		if expectedContent == nil {
+			return successFunc()
+		}
+
+		// Compare to expected content.
+		expectedBytes, err := json.Marshal(expectedContent)
+		if err != nil {
+			t.Fail()
+			return nil, err
+		}
+
+		if r.Body == nil {
+			t.Fail()
+			return nil, fmt.Errorf("expected body on request")
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fail()
+			return nil, err
+		}
+
+		var bodyInterface map[string]interface{}
+		if err = json.Unmarshal(bodyBytes, &bodyInterface); err == nil {
+			var expectedInterface map[string]interface{}
+
+			err = json.Unmarshal(expectedBytes, &expectedInterface)
+			if err != nil {
+				return nil, err
+			}
+
+			diff := deep.Equal(bodyInterface, expectedInterface)
+			if diff == nil {
+				return successFunc()
+			}
+		} else {
+			return nil, err
+		}
+
+		return successFunc()
+	}
+}
+
+// Register a new responder when the given call is made.
+func changeStateResponder(registerFunc func(), successResponse int, successResponseBody interface{}) httpmock.Responder {
+	return func(r *http.Request) (*http.Response, error) {
+		registerFunc()
+		return httpmock.NewJsonResponse(successResponse, successResponseBody)
+	}
+}
+
+// Function to set up HTTP mocks for the kubernetes secret requests anticipated by this test, when not being run against a real TMC stack.
+// nolint: ineffassign,staticcheck
+func (testConfig *testAcceptanceConfig) setupHTTPMocks(t *testing.T) {
+	httpmock.Activate()
+	t.Cleanup(httpmock.Deactivate)
+
+	endpoint := os.Getenv("TMC_ENDPOINT")
+
+	OrgID := os.Getenv("ORG_ID")
+
+	// POST
+	secretSpec := getMockSpec()
+	postRequestModel := &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecret{
+		FullName: &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecretFullName{
+			Name:          testConfig.SecretName,
+			OrgID:         OrgID,
+			ClusterName:   testConfig.ClusterName,
+			NamespaceName: testConfig.NamespaceName,
+		},
+		Spec: &secretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "secret1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	reference := objectmetamodel.VmwareTanzuCoreV1alpha1ObjectReference{
+		Rid: "test_rid",
+		UID: "test_uid",
+	}
+	referenceArray := make([]*objectmetamodel.VmwareTanzuCoreV1alpha1ObjectReference, 0)
+	referenceArray = append(referenceArray, &reference)
+
+	postResponseModel := &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecret{
+		FullName: &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecretFullName{
+			Name:          testConfig.SecretName,
+			OrgID:         OrgID,
+			ClusterName:   testConfig.ClusterName,
+			NamespaceName: testConfig.NamespaceName,
+		},
+		Spec: &secretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "secret1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	postRequest := &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecretRequest{
+		Secret: postRequestModel,
+	}
+
+	postResponse := &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecretResponse{
+		Secret: postResponseModel,
+	}
+
+	// GET Network Secret mock setup
+	getModel := &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecret{
+		FullName: &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceSecretFullName{
+			Name:          testConfig.SecretName,
+			OrgID:         OrgID,
+			ClusterName:   testConfig.ClusterName,
+			NamespaceName: testConfig.NamespaceName,
+		},
+		Spec: &secretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "secret1",
+			ResourceVersion: "v1",
+		},
+		Status: &status.VmwareTanzuManageV1alpha1ClusterNamespaceStatus{
+			Conditions: map[string]status.VmwareTanzuCoreV1alpha1StatusCondition{
+				"Ready": {
+					Reason: "made successfully",
+				},
+			},
+		},
+	}
+
+	getResponse := &secretmodel.VmwareTanzuManageV1alpha1ClusterNamespaceGetSecretResponse{
+		Secret: getModel,
+	}
+
+	postEndpoint := (helper.ConstructRequestURL(https, endpoint, apiVersionAndGroup, testConfig.ClusterName, apiSubGroup, testConfig.NamespaceName, apiKind)).String()
+	getSecretEndpoint := (helper.ConstructRequestURL(https, endpoint, apiVersionAndGroup, testConfig.ClusterName, apiSubGroup, testConfig.NamespaceName, apiKind, testConfig.SecretName)).String()
+	deleteEndpoint := getSecretEndpoint
+
+	getSecretExportEndpoint := (helper.ConstructRequestURL(https, endpoint, apiVersionAndGroup, testConfig.ClusterName, apiSubGroup, testConfig.NamespaceName, exportAPIKind, testConfig.SecretName)).String()
+	deleteExportEndpoint := getSecretExportEndpoint
+
+	httpmock.RegisterResponder("POST", postEndpoint,
+		bodyInspectingResponder(t, postRequest, 200, postResponse))
+
+	httpmock.RegisterResponder("GET", getSecretEndpoint,
+		bodyInspectingResponder(t, nil, 200, getResponse))
+
+	httpmock.RegisterResponder("DELETE", deleteEndpoint, changeStateResponder(
+		// Set up the get to return 404 after the Secret has been 'deleted'
+		func() {
+			httpmock.RegisterResponder("GET", getSecretEndpoint,
+				httpmock.NewStringResponder(404, "Not found"))
+		},
+		http.StatusOK,
+		nil))
+
+	httpmock.RegisterResponder("DELETE", deleteExportEndpoint, changeStateResponder(
+		// Set up the get to return 404 after the Secret has been 'deleted'
+		func() {
+			httpmock.RegisterResponder("GET", getSecretExportEndpoint,
+				httpmock.NewStringResponder(404, "Not found"))
+		},
+		http.StatusOK,
+		nil))
+}

--- a/internal/resources/kubernetessecret/resource_secret_test.go
+++ b/internal/resources/kubernetessecret/resource_secret_test.go
@@ -6,10 +6,13 @@ SPDX-License-Identifier: MPL-2.0
 package kubernetessecret
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -36,6 +39,8 @@ type testAcceptanceConfig struct {
 	SecretResourceVar  string
 	SecretResourceName string
 	SecretName         string
+	ClusterName        string
+	NamespaceName      string
 }
 
 func testGetDefaultAcceptanceConfig(t *testing.T) *testAcceptanceConfig {
@@ -45,13 +50,56 @@ func testGetDefaultAcceptanceConfig(t *testing.T) *testAcceptanceConfig {
 		SecretResourceVar:  secretResourceVar,
 		SecretResourceName: fmt.Sprintf("%s.%s", ResourceName, secretResourceVar),
 		SecretName:         acctest.RandomWithPrefix("tf-sc-test"),
+		NamespaceName:      "default",
+		ClusterName:        acctest.RandomWithPrefix("tf-cluster"),
 	}
 }
 
-func TestAcceptanceForSecretResource(t *testing.T) {
-	clusterName := acctest.RandomWithPrefix("tf-cluster")
+func getConfigureContextFunc() func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	if _, found := os.LookupEnv("ENABLE_SECRET_ENV_TEST"); !found {
+		return authctx.ProviderConfigureContextWithDefaultTransportForTesting
+	}
 
+	return authctx.ProviderConfigureContext
+}
+
+func getSetupConfig(config *authctx.TanzuContext) error {
+	if _, found := os.LookupEnv("ENABLE_SECRET_ENV_TEST"); !found {
+		return config.SetupWithDefaultTransportForTesting()
+	}
+
+	return config.Setup()
+}
+
+func TestAcceptanceForSecretResource(t *testing.T) {
 	testConfig := testGetDefaultAcceptanceConfig(t)
+
+	// If the flag to execute kubernetes secret tests is not found, run this as a mock test by setting up an http intercept for each endpoint.
+	if _, found := os.LookupEnv("ENABLE_SECRET_ENV_TEST"); !found {
+		os.Setenv("TF_ACC", "true")
+		os.Setenv("TMC_ENDPOINT", "dummy.tmc.mock.vmware.com")
+		os.Setenv("VMW_CLOUD_API_TOKEN", "dummy")
+		os.Setenv("VMW_CLOUD_ENDPOINT", "console.cloud.vmware.com")
+
+		log.Println("Setting up the mock endpoints...")
+
+		testConfig.setupHTTPMocks(t)
+	} else {
+		// Environment variables with non default values required for a successful call to MKP
+		requiredVars := []string{
+			"VMW_CLOUD_ENDPOINT",
+			"TMC_ENDPOINT",
+			"VMW_CLOUD_API_TOKEN",
+			"ORG_ID",
+		}
+
+		// Check if the required environment variables are set
+		for _, name := range requiredVars {
+			if _, found := os.LookupEnv(name); !found {
+				t.Errorf("required environment variable '%s' missing", name)
+			}
+		}
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testhelper.TestPreCheck(t),
@@ -59,9 +107,9 @@ func TestAcceptanceForSecretResource(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testConfig.getTestResourceClusterGroupConfigValue(t, clusterName),
+				Config: testConfig.getTestResourceClusterGroupConfigValue(t),
 				Check: resource.ComposeTestCheckFunc(
-					testConfig.checkResourceAttributes(testConfig.Provider, testConfig.SecretResource, clusterName, testConfig.SecretName),
+					testConfig.checkResourceAttributes(testConfig.Provider, testConfig.SecretResource, testConfig.SecretName),
 				),
 			},
 		},
@@ -70,7 +118,32 @@ func TestAcceptanceForSecretResource(t *testing.T) {
 	t.Log("secret resource acceptance test complete!")
 }
 
-func (testConfig *testAcceptanceConfig) getTestResourceClusterGroupConfigValue(t *testing.T, clusterName string) string {
+func (testConfig *testAcceptanceConfig) getTestResourceClusterGroupConfigValue(t *testing.T, opts ...OperationOption) string {
+	secretSpec := testConfig.getTestSecretResourceSpec(opts...)
+
+	if _, found := os.LookupEnv("ENABLE_SECRET_ENV_TEST"); !found {
+		return fmt.Sprintf(`
+
+resource "%s" "%s" {
+  name = "%s"
+
+  namespace_name = "default"
+
+  scope {
+	cluster {
+		management_cluster_name = "attached"
+		provisioner_name = "attached"
+		cluster_name = "%s"
+	}
+  }
+
+  %s
+
+}
+
+`, testConfig.SecretResource, testConfig.SecretResourceVar, testConfig.SecretName, testConfig.ClusterName, secretSpec)
+	}
+
 	kubeconfigPath := os.Getenv("KUBECONFIG")
 	if kubeconfigPath == "" {
 		t.Skipf("KUBECONFIG env var is not set: %s", kubeconfigPath)
@@ -87,7 +160,7 @@ resource "%s" "%s" {
   attach_k8s_cluster {
     kubeconfig_file = "%s"
   }
- 
+
   spec {
     cluster_group = "default"
   }
@@ -108,23 +181,17 @@ resource "%s" "%s" {
 	}
   }
 
-  spec {
-	docker_config_json {
-		username = "someusername"
-		password = "somepassword"
-		image_registry_url = "someregistryurl"
-	}
-  }
+  %s
 
 }
 
-`, clusterResource, clusterResourceVar, scope.AttachedValue, scope.AttachedValue, clusterName, testhelper.MetaTemplate, kubeconfigPath,
-		testConfig.SecretResource, testConfig.SecretResourceVar, testConfig.SecretName)
+`, clusterResource, clusterResourceVar, scope.AttachedValue, scope.AttachedValue, testConfig.ClusterName, testhelper.MetaTemplate, kubeconfigPath,
+		testConfig.SecretResource, testConfig.SecretResourceVar, testConfig.SecretName, secretSpec)
 }
 
-func (testConfig *testAcceptanceConfig) checkResourceAttributes(provider *schema.Provider, resourceName, clusterName, secretName string) resource.TestCheckFunc {
+func (testConfig *testAcceptanceConfig) checkResourceAttributes(provider *schema.Provider, resourceName, secretName string) resource.TestCheckFunc {
 	var check = []resource.TestCheckFunc{
-		testConfig.verifySecretResourceCreation(provider, resourceName, clusterName, secretName),
+		testConfig.verifySecretResourceCreation(provider, resourceName, testConfig.ClusterName, secretName),
 		resource.TestCheckResourceAttr(testConfig.SecretResourceName, "name", testConfig.SecretName),
 	}
 
@@ -161,7 +228,7 @@ func (testConfig *testAcceptanceConfig) verifySecretResourceCreation(
 			TLSConfig:        &proxy.TLSConfig{},
 		}
 
-		err := config.Setup()
+		err := getSetupConfig(&config)
 		if err != nil {
 			return errors.Wrap(err, "unable to set the context")
 		}
@@ -171,7 +238,7 @@ func (testConfig *testAcceptanceConfig) verifySecretResourceCreation(
 			ClusterName:           clusterName,
 			ManagementClusterName: "attached",
 			ProvisionerName:       "attached",
-			NamespaceName:         "default",
+			NamespaceName:         testConfig.NamespaceName,
 		}
 
 		resp, err := config.TMCConnection.SecretResourceService.SecretResourceServiceGet(fn)
@@ -185,4 +252,55 @@ func (testConfig *testAcceptanceConfig) verifySecretResourceCreation(
 
 		return nil
 	}
+}
+
+type (
+	OperationConfig struct {
+		username         string
+		password         string
+		imageRegistryURL string
+	}
+
+	OperationOption func(*OperationConfig)
+)
+
+func WithUsername(val string) OperationOption {
+	return func(config *OperationConfig) {
+		config.username = val
+	}
+}
+
+func WithPassword(val string) OperationOption {
+	return func(config *OperationConfig) {
+		config.password = val
+	}
+}
+
+func WithURL(val string) OperationOption {
+	return func(config *OperationConfig) {
+		config.imageRegistryURL = val
+	}
+}
+
+// getTestSecretResourceSpec builds the input block for git repository resource based a recipe.
+func (testConfig *testAcceptanceConfig) getTestSecretResourceSpec(opts ...OperationOption) string {
+	cfg := &OperationConfig{
+		username:         "someusername",
+		password:         "somepassword",
+		imageRegistryURL: "someregistryurl",
+	}
+
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	secretSpec := fmt.Sprintf(`  spec {
+	docker_config_json {
+		username = "%s"
+		password = "%s"
+		image_registry_url = "%s"
+	}
+  }`, cfg.username, cfg.password, cfg.imageRegistryURL)
+
+	return secretSpec
 }

--- a/internal/resources/kubernetessecret/secret_provider_test.go
+++ b/internal/resources/kubernetessecret/secret_provider_test.go
@@ -27,7 +27,7 @@ func initTestProvider(t *testing.T) *schema.Provider {
 			ResourceName:         DataSourceSecret(),
 			cluster.ResourceName: cluster.DataSourceTMCCluster(),
 		},
-		ConfigureContextFunc: authctx.ProviderConfigureContext,
+		ConfigureContextFunc: getConfigureContextFunc(),
 	}
 	if err := testProvider.InternalValidate(); err != nil {
 		require.NoError(t, err)


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Add Mock Acceptance tests for kubernetes secret resource 

<img width="1512" alt="Screenshot 2023-07-06 at 10 33 50 AM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/57012922/f95055aa-65d3-451f-a435-a8e92cbcfb12">

