### PR TITLE
Fix the failing network policy unit test

### DIFF
--- a/internal/resources/policy/kind/network/input_flatten_test.go
+++ b/internal/resources/policy/kind/network/input_flatten_test.go
@@ -66,11 +66,8 @@ func TestFlattenInput(t *testing.T) {
 					reciperesource.AllowAllToPodsKey: []interface{}{
 						map[string]interface{}{
 							reciperesource.FromOwnNamespaceKey: true,
-							reciperesource.ToPodLabelsKey: []interface{}{
-								map[string]interface{}{
-									reciperesource.LabelKey:      "foo",
-									reciperesource.LabelValueKey: "bar",
-								},
+							reciperesource.ToPodLabelsKey: map[string]interface{}{
+								"foo": "bar",
 							},
 						},
 					},
@@ -120,11 +117,8 @@ func TestFlattenInput(t *testing.T) {
 				map[string]interface{}{
 					reciperesource.DenyAllToPodsKey: []interface{}{
 						map[string]interface{}{
-							reciperesource.ToPodLabelsKey: []interface{}{
-								map[string]interface{}{
-									reciperesource.LabelKey:      "foo",
-									reciperesource.LabelValueKey: "bar",
-								},
+							reciperesource.ToPodLabelsKey: map[string]interface{}{
+								"foo": "bar",
 							},
 						},
 					},


### PR DESCRIPTION
Thee expected output for allow-all-pods and deny-all-pods recipe was wrongly constructed. Pod labels is of the type map in the schema and not a list, hence added the fix accordingly.
Signed-off-by: Ramya Bangera <bangerar@vmware.com>

1. **What this PR does / why we need it**:
The expected output for allow-all-pods and deny-all-pods recipe was wrongly constructed. Pod labels is of the type map in the schema and not a list, hence added the fix accordingly.
2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->