### PR TITLE
Add mock acceeptance test for source secret

### DIFF
--- a/internal/resources/sourcesecret/resource_sourcesecret_mock_test.go
+++ b/internal/resources/sourcesecret/resource_sourcesecret_mock_test.go
@@ -1,0 +1,625 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package sourcesecret
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-test/deep"
+	"github.com/jarcoal/httpmock"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	continuousdeliveryclustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/continuousdelivery/cluster"
+	continuousdeliveryclustergroupmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/continuousdelivery/clustergroup"
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+	sourcesecretclustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/sourcesecret/cluster"
+	sourcesecretclustergroupmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/sourcesecret/clustergroup"
+	statusmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/status"
+	commonscope "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common/scope"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/sourcesecret/spec"
+)
+
+const (
+	https                = "https:/"
+	clAPIVersionAndGroup = "v1alpha1/clusters"
+	apiKind              = "fluxcd/sourcesecrets"
+	cdAPIKind            = "fluxcd/continuousdelivery"
+	cgAPIVersionAndGroup = "v1alpha1/clustergroups"
+)
+
+func getMockSpec(allowedCredential string) sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec {
+	switch allowedCredential {
+	case spec.UsernamePasswordKey:
+		return sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{
+			SourceSecretType: sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeUSERNAMEPASSWORD),
+			Data: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpec{
+				Data: map[string]strfmt.Base64{
+					"username": []byte("testusername"),
+					"password": []byte(""),
+				},
+			},
+		}
+	case spec.SSHKey:
+		return sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{
+			SourceSecretType: sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeSSH),
+			Data: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpec{
+				Data: map[string]strfmt.Base64{
+					"identity":    []byte(""),
+					"known_hosts": []byte("testhostes"),
+				},
+			},
+		}
+	default:
+		return sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{}
+	}
+}
+
+// nolint: unparam
+func bodyInspectingResponder(t *testing.T, expectedContent interface{}, successResponse int, successResponseBody interface{}) httpmock.Responder {
+	return func(r *http.Request) (*http.Response, error) {
+		successFunc := func() (*http.Response, error) {
+			return httpmock.NewJsonResponse(successResponse, successResponseBody)
+		}
+
+		if expectedContent == nil {
+			return successFunc()
+		}
+
+		// Compare to expected content.
+		expectedBytes, err := json.Marshal(expectedContent)
+		if err != nil {
+			t.Fail()
+			return nil, err
+		}
+
+		if r.Body == nil {
+			t.Fail()
+			return nil, fmt.Errorf("expected body on request")
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fail()
+			return nil, err
+		}
+
+		var bodyInterface map[string]interface{}
+		if err = json.Unmarshal(bodyBytes, &bodyInterface); err == nil {
+			var expectedInterface map[string]interface{}
+
+			err = json.Unmarshal(expectedBytes, &expectedInterface)
+			if err != nil {
+				return nil, err
+			}
+
+			diff := deep.Equal(bodyInterface, expectedInterface)
+			if diff == nil {
+				return successFunc()
+			}
+		} else {
+			return nil, err
+		}
+
+		return successFunc()
+	}
+}
+
+// Register a new responder when the given call is made.
+func changeStateResponder(registerFunc func(), successResponse int, successResponseBody interface{}) httpmock.Responder {
+	return func(r *http.Request) (*http.Response, error) {
+		registerFunc()
+		return httpmock.NewJsonResponse(successResponse, successResponseBody)
+	}
+}
+
+func (testConfig *testAcceptanceConfig) setupHTTPMocksUpdate(t *testing.T, scope commonscope.Scope) {
+	httpmock.Activate()
+	t.Cleanup(httpmock.Deactivate)
+
+	endpoint := os.Getenv("TMC_ENDPOINT")
+
+	OrgID := os.Getenv("ORG_ID")
+
+	reference := objectmetamodel.VmwareTanzuCoreV1alpha1ObjectReference{
+		Rid: "test_rid",
+		UID: "test_uid",
+	}
+	referenceArray := make([]*objectmetamodel.VmwareTanzuCoreV1alpha1ObjectReference, 0)
+	referenceArray = append(referenceArray, &reference)
+
+	switch scope {
+	case commonscope.ClusterScope:
+		getModel := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecret{
+			FullName: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretFullName{
+				Name:                  testConfig.SourceSecretName,
+				OrgID:                 OrgID,
+				ClusterName:           testConfig.ScopeHelperResources.Cluster.Name,
+				ProvisionerName:       "attached",
+				ManagementClusterName: "attached",
+			},
+			Spec: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{
+				SourceSecretType: sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeUSERNAMEPASSWORD),
+				Data: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpec{
+					Data: map[string]strfmt.Base64{
+						"username": []byte("someusername"),
+						"password": []byte(""),
+					},
+				},
+			},
+			Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+				ParentReferences: referenceArray,
+				Description:      "resource with description",
+				Labels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				UID:             "kustomization1",
+				ResourceVersion: "v1",
+			},
+		}
+
+		getResponse := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdGetSourceSecretResponse{
+			SourceSecret: getModel,
+		}
+		getSourcesecretEndpoint := (helper.ConstructRequestURL(https, endpoint, clAPIVersionAndGroup, testConfig.ScopeHelperResources.Cluster.Name, apiKind, testConfig.SourceSecretName)).String()
+
+		httpmock.RegisterResponder("GET", getSourcesecretEndpoint,
+			bodyInspectingResponder(t, nil, 200, getResponse))
+	case commonscope.ClusterGroupScope:
+		getCGModel := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSourceSecret{
+			FullName: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretFullName{
+				Name:             testConfig.SourceSecretName,
+				OrgID:            OrgID,
+				ClusterGroupName: testConfig.ScopeHelperResources.ClusterGroup.Name,
+			},
+			Spec: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSpec{
+				AtomicSpec: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{
+					SourceSecretType: sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeSSH),
+					Data: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpec{
+						Data: map[string]strfmt.Base64{
+							"identity":    []byte(""),
+							"known_hosts": []byte("somehosts"),
+						},
+					},
+				},
+			},
+			Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+				ParentReferences: referenceArray,
+				Description:      "resource with description",
+				Labels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				UID:             "cdkustomization1",
+				ResourceVersion: "v1",
+			},
+		}
+
+		getCGResponse := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdGetSourceSecretResponse{
+			SourceSecret: getCGModel,
+		}
+
+		getCGSourcesecretEndpoint := (helper.ConstructRequestURL(https, endpoint, cgAPIVersionAndGroup, testConfig.ScopeHelperResources.ClusterGroup.Name, apiKind, testConfig.SourceSecretName)).String()
+
+		httpmock.RegisterResponder("GET", getCGSourcesecretEndpoint,
+			bodyInspectingResponder(t, nil, 200, getCGResponse))
+	}
+}
+
+func (testConfig *testAcceptanceConfig) setupHTTPMocks(t *testing.T) {
+	httpmock.Activate()
+	t.Cleanup(httpmock.Deactivate)
+
+	endpoint := os.Getenv("TMC_ENDPOINT")
+
+	OrgID := os.Getenv("ORG_ID")
+
+	reference := objectmetamodel.VmwareTanzuCoreV1alpha1ObjectReference{
+		Rid: "test_rid",
+		UID: "test_uid",
+	}
+	referenceArray := make([]*objectmetamodel.VmwareTanzuCoreV1alpha1ObjectReference, 0)
+	referenceArray = append(referenceArray, &reference)
+
+	// cluster level source secret resorce.
+	postRequest, postResponse, getResponse, postContinuousDeliveryRequest, postContinuousDeliveryResponse := testConfig.getClRequestResponse(OrgID, referenceArray)
+
+	putRequest := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourceSecretRequest{
+		SourceSecret: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecret{
+			FullName: postRequest.SourceSecret.FullName,
+			Meta:     postRequest.SourceSecret.Meta,
+			Spec: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{
+				SourceSecretType: sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeUSERNAMEPASSWORD),
+				Data: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpec{
+					Data: map[string]strfmt.Base64{
+						"username": []byte("someusername"),
+						"password": []byte(""),
+					},
+				},
+			},
+		},
+	}
+
+	putResponse := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretResponse{
+		SourceSecret: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecret{
+			FullName: postRequest.SourceSecret.FullName,
+			Meta:     postRequest.SourceSecret.Meta,
+			Spec: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{
+				SourceSecretType: sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeUSERNAMEPASSWORD),
+				Data: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpec{
+					Data: map[string]strfmt.Base64{
+						"username": []byte("someusername"),
+						"password": []byte(""),
+					},
+				},
+			},
+		},
+	}
+
+	postEndpoint := (helper.ConstructRequestURL(https, endpoint, clAPIVersionAndGroup, testConfig.ScopeHelperResources.Cluster.Name, apiKind)).String()
+	getSourcesecretEndpoint := (helper.ConstructRequestURL(https, endpoint, clAPIVersionAndGroup, testConfig.ScopeHelperResources.Cluster.Name, apiKind, testConfig.SourceSecretName)).String()
+	deleteEndpoint := getSourcesecretEndpoint
+
+	postContinuousDeliveryEndpoint := (helper.ConstructRequestURL(https, endpoint, clAPIVersionAndGroup, testConfig.ScopeHelperResources.Cluster.Name, cdAPIKind)).String()
+
+	httpmock.RegisterResponder("POST", postContinuousDeliveryEndpoint,
+		bodyInspectingResponder(t, postContinuousDeliveryRequest, 200, postContinuousDeliveryResponse))
+
+	httpmock.RegisterResponder("POST", postEndpoint,
+		bodyInspectingResponder(t, postRequest, 200, postResponse))
+
+	httpmock.RegisterResponder("PUT", getSourcesecretEndpoint,
+		bodyInspectingResponder(t, putRequest, 200, putResponse))
+
+	httpmock.RegisterResponder("GET", getSourcesecretEndpoint,
+		bodyInspectingResponder(t, nil, 200, getResponse))
+
+	httpmock.RegisterResponder("DELETE", deleteEndpoint, changeStateResponder(
+		// Set up the get to return 404 after the Secret has been 'deleted'.
+		func() {
+			httpmock.RegisterResponder("GET", getSourcesecretEndpoint,
+				httpmock.NewStringResponder(404, "Not found"))
+		},
+		http.StatusOK,
+		nil))
+
+	// cluster group level source secret resorce.
+	postCGRequest, postCGResponse, getCGResponse, postCGContinuousDeliveryRequest, postCGContinuousDeliveryResponse := testConfig.getCGRequestResponse(OrgID, referenceArray)
+
+	putCGRequest := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourceSecretRequest{
+		SourceSecret: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSourceSecret{
+			FullName: postCGRequest.SourceSecret.FullName,
+			Meta:     postCGRequest.SourceSecret.Meta,
+			Spec: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSpec{
+				AtomicSpec: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{
+					SourceSecretType: sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeSSH),
+					Data: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpec{
+						Data: map[string]strfmt.Base64{
+							"identity":    []byte(""),
+							"known_hosts": []byte("somehosts"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	putCGResponse := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourceSecretResponse{
+		SourceSecret: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSourceSecret{
+			FullName: postCGRequest.SourceSecret.FullName,
+			Meta:     postCGRequest.SourceSecret.Meta,
+			Spec: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSpec{
+				AtomicSpec: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec{
+					SourceSecretType: sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeSSH),
+					Data: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpec{
+						Data: map[string]strfmt.Base64{
+							"identity":    []byte(""),
+							"known_hosts": []byte("somehosts"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	postCDEndpoint := (helper.ConstructRequestURL(https, endpoint, cgAPIVersionAndGroup, testConfig.ScopeHelperResources.ClusterGroup.Name, apiKind)).String()
+	getCGSourcesecretEndpoint := (helper.ConstructRequestURL(https, endpoint, cgAPIVersionAndGroup, testConfig.ScopeHelperResources.ClusterGroup.Name, apiKind, testConfig.SourceSecretName)).String()
+	deleteCGEndpoint := getCGSourcesecretEndpoint
+
+	postCDContinuousDeliveryEndpoint := (helper.ConstructRequestURL(https, endpoint, cgAPIVersionAndGroup, testConfig.ScopeHelperResources.ClusterGroup.Name, cdAPIKind)).String()
+
+	httpmock.RegisterResponder("POST", postCDContinuousDeliveryEndpoint,
+		bodyInspectingResponder(t, postCGContinuousDeliveryRequest, 200, postCGContinuousDeliveryResponse))
+
+	httpmock.RegisterResponder("POST", postCDEndpoint,
+		bodyInspectingResponder(t, postCGRequest, 200, postCGResponse))
+
+	httpmock.RegisterResponder("GET", getCGSourcesecretEndpoint,
+		bodyInspectingResponder(t, nil, 200, getCGResponse))
+
+	httpmock.RegisterResponder("PUT", getCGSourcesecretEndpoint,
+		bodyInspectingResponder(t, putCGRequest, 200, putCGResponse))
+
+	httpmock.RegisterResponder("DELETE", deleteCGEndpoint, changeStateResponder(
+		// Set up the get to return 404 after the Secret has been 'deleted'.
+		func() {
+			httpmock.RegisterResponder("GET", getCGSourcesecretEndpoint,
+				httpmock.NewStringResponder(404, "Not found"))
+		},
+		http.StatusOK,
+		nil))
+}
+
+func (testConfig *testAcceptanceConfig) getCGRequestResponse(orgID string, referenceArray []*objectmetamodel.VmwareTanzuCoreV1alpha1ObjectReference) (
+	*sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourceSecretRequest,
+	*sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourceSecretResponse,
+	*sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdGetSourceSecretResponse,
+	*continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryContinuousDeliveryRequest,
+	*continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryContinuousDeliveryResponse,
+) {
+	sourcesecretSpec := getMockSpec(spec.UsernamePasswordKey)
+
+	cgSourcesecretSpec := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSpec{
+		AtomicSpec: &sourcesecretSpec,
+	}
+
+	postCGRequestModel := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSourceSecret{
+		FullName: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretFullName{
+			Name:             testConfig.SourceSecretName,
+			OrgID:            orgID,
+			ClusterGroupName: testConfig.ScopeHelperResources.ClusterGroup.Name,
+		},
+		Spec: cgSourcesecretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "cdkustomization1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	postCGResponseModel := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSourceSecret{
+		FullName: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretFullName{
+			Name:             testConfig.SourceSecretName,
+			OrgID:            orgID,
+			ClusterGroupName: testConfig.ScopeHelperResources.ClusterGroup.Name,
+		},
+		Spec: cgSourcesecretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "cdkustomization1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	postCGRequest := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourceSecretRequest{
+		SourceSecret: postCGRequestModel,
+	}
+
+	postCGResponse := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourceSecretResponse{
+		SourceSecret: postCGResponseModel,
+	}
+
+	getCGModel := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretSourceSecret{
+		FullName: &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdSourcesecretFullName{
+			Name:             testConfig.SourceSecretName,
+			OrgID:            orgID,
+			ClusterGroupName: testConfig.ScopeHelperResources.ClusterGroup.Name,
+		},
+		Spec: cgSourcesecretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: referenceArray,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "cdkustomization1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	getCGResponse := &sourcesecretclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdGetSourceSecretResponse{
+		SourceSecret: getCGModel,
+	}
+
+	postRequestCGContinuousDeliveryModel := &continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryContinuousDelivery{
+		FullName: &continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryFullName{
+			ClusterGroupName: testConfig.ScopeHelperResources.ClusterGroup.Name,
+			OrgID:            orgID,
+		},
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "cdcontinuousdelivery1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	postResponseCGContinuousDelivery := &continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryContinuousDelivery{
+		FullName: &continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryFullName{
+			ClusterGroupName: testConfig.ScopeHelperResources.ClusterGroup.Name,
+			OrgID:            orgID,
+		},
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "cdcontinuousdelivery1",
+			ResourceVersion: "v1",
+		},
+		Status: &continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryStatus{
+			Phase: statusmodel.NewVmwareTanzuManageV1alpha1CommonBatchPhase(statusmodel.VmwareTanzuManageV1alpha1CommonBatchPhaseAPPLIED),
+		},
+	}
+
+	postCGContinuousDeliveryRequest := &continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryContinuousDeliveryRequest{
+		ContinuousDelivery: postRequestCGContinuousDeliveryModel,
+	}
+
+	postCGContinuousDeliveryResponse := &continuousdeliveryclustergroupmodel.VmwareTanzuManageV1alpha1ClustergroupFluxcdContinuousdeliveryContinuousDeliveryResponse{
+		ContinuousDelivery: postResponseCGContinuousDelivery,
+	}
+
+	return postCGRequest, postCGResponse, getCGResponse, postCGContinuousDeliveryRequest, postCGContinuousDeliveryResponse
+}
+
+func (testConfig *testAcceptanceConfig) getClRequestResponse(orgID string, referenceArray []*objectmetamodel.VmwareTanzuCoreV1alpha1ObjectReference) (
+	*sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourceSecretRequest,
+	*sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretResponse,
+	*sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdGetSourceSecretResponse,
+	*continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryContinuousDeliveryRequest,
+	*continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryContinuousDeliveryResponse,
+) {
+	sourcesecretSpec := getMockSpec(spec.SSHKey)
+	postRequestModel := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecret{
+		FullName: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretFullName{
+			Name:                  testConfig.SourceSecretName,
+			OrgID:                 orgID,
+			ClusterName:           testConfig.ScopeHelperResources.Cluster.Name,
+			ProvisionerName:       "attached",
+			ManagementClusterName: "attached",
+		},
+		Spec: &sourcesecretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "kustomization1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	postResponseModel := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecret{
+		FullName: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretFullName{
+			Name:                  testConfig.SourceSecretName,
+			OrgID:                 orgID,
+			ClusterName:           testConfig.ScopeHelperResources.Cluster.Name,
+			ProvisionerName:       "attached",
+			ManagementClusterName: "attached",
+		},
+		Spec: &sourcesecretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "kustomization1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	postRequest := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourceSecretRequest{
+		SourceSecret: postRequestModel,
+	}
+
+	postResponse := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretResponse{
+		SourceSecret: postResponseModel,
+	}
+
+	getModel := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecret{
+		FullName: &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretFullName{
+			Name:                  testConfig.SourceSecretName,
+			OrgID:                 orgID,
+			ClusterName:           testConfig.ScopeHelperResources.Cluster.Name,
+			ProvisionerName:       "attached",
+			ManagementClusterName: "attached",
+		},
+		Spec: &sourcesecretSpec,
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: referenceArray,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "kustomization1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	getResponse := &sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdGetSourceSecretResponse{
+		SourceSecret: getModel,
+	}
+
+	postRequestContinuousDeliveryModel := &continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryContinuousDelivery{
+		FullName: &continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryFullName{
+			ClusterName: testConfig.ScopeHelperResources.Cluster.Name,
+			OrgID:       orgID,
+		},
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "continuousdelivery1",
+			ResourceVersion: "v1",
+		},
+	}
+
+	postResponseContinuousDelivery := &continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryContinuousDelivery{
+		FullName: &continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryFullName{
+			ClusterName: testConfig.ScopeHelperResources.Cluster.Name,
+			OrgID:       orgID,
+		},
+		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
+			ParentReferences: nil,
+			Description:      "resource with description",
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			UID:             "continuousdelivery1",
+			ResourceVersion: "v1",
+		},
+		Status: &continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryStatus{
+			Conditions: map[string]statusmodel.VmwareTanzuCoreV1alpha1StatusCondition{
+				"Ready": {
+					Reason: "made successfully",
+				},
+			},
+		},
+	}
+
+	postContinuousDeliveryRequest := &continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryContinuousDeliveryRequest{
+		ContinuousDelivery: postRequestContinuousDeliveryModel,
+	}
+
+	postContinuousDeliveryResponse := &continuousdeliveryclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdContinuousdeliveryContinuousDeliveryResponse{
+		ContinuousDelivery: postResponseContinuousDelivery,
+	}
+
+	return postRequest, postResponse, getResponse, postContinuousDeliveryRequest, postContinuousDeliveryResponse
+}

--- a/internal/resources/sourcesecret/resource_sourcesecret_test.go
+++ b/internal/resources/sourcesecret/resource_sourcesecret_test.go
@@ -6,12 +6,14 @@ SPDX-License-Identifier: MPL-2.0
 package sourcesecret
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -60,12 +62,55 @@ func testGetDefaultAcceptanceConfig(t *testing.T) *testAcceptanceConfig {
 	}
 }
 
+func getConfigureContextFunc() func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	if _, found := os.LookupEnv("ENABLE_REPOCRED_ENV_TEST"); !found {
+		return authctx.ProviderConfigureContextWithDefaultTransportForTesting
+	}
+
+	return authctx.ProviderConfigureContext
+}
+
+func getSetupConfig(config *authctx.TanzuContext) error {
+	if _, found := os.LookupEnv("ENABLE_REPOCRED_ENV_TEST"); !found {
+		return config.SetupWithDefaultTransportForTesting()
+	}
+
+	return config.Setup()
+}
+
 func TestAcceptanceForSourceSecretResource(t *testing.T) {
 	testConfig := testGetDefaultAcceptanceConfig(t)
 
+	// If the flag to execute source secret tests is not found, run this as a mock test by setting up an http intercept for each endpoint.
+	_, found := os.LookupEnv("ENABLE_REPOCRED_ENV_TEST")
+	if !found {
+		os.Setenv("TF_ACC", "true")
+		os.Setenv("TMC_ENDPOINT", "dummy.tmc.mock.vmware.com")
+		os.Setenv("VMW_CLOUD_API_TOKEN", "dummy")
+		os.Setenv("VMW_CLOUD_ENDPOINT", "console.cloud.vmware.com")
+
+		log.Println("Setting up the mock endpoints...")
+		testConfig.setupHTTPMocks(t)
+	} else {
+		// Environment variables with non default values required for a successful call to Cluster Config Service.
+		requiredVars := []string{
+			"VMW_CLOUD_ENDPOINT",
+			"TMC_ENDPOINT",
+			"VMW_CLOUD_API_TOKEN",
+			"ORG_ID",
+		}
+
+		// Check if the required environment variables are set.
+		for _, name := range requiredVars {
+			if _, found := os.LookupEnv(name); !found {
+				t.Errorf("required environment variable '%s' missing", name)
+			}
+		}
+	}
+
 	t.Log("start source secret resource acceptance tests!")
 
-	// Test case for source secret resource with baseline recipe.
+	// Test case for source secret resource.
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testhelper.TestPreCheck(t),
 		ProviderFactories: testhelper.GetTestProviderFactories(testConfig.Provider),
@@ -73,7 +118,7 @@ func TestAcceptanceForSourceSecretResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					if testConfig.ScopeHelperResources.Cluster.KubeConfigPath == "" {
+					if testConfig.ScopeHelperResources.Cluster.KubeConfigPath == "" && found {
 						t.Skip("KUBECONFIG env var is not set for cluster scoped source secret acceptance test")
 					}
 				},
@@ -81,60 +126,84 @@ func TestAcceptanceForSourceSecretResource(t *testing.T) {
 				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterScope),
 			},
 			{
-				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterScope, spec.SSHKey, WithKnownhosts("somehostes")),
+				PreConfig: func() {
+					if !found {
+						t.Log("Setting up the updated GET mock responder for cluster scope...")
+						testConfig.setupHTTPMocksUpdate(t, commonscope.ClusterScope)
+					}
+				},
+				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterScope, spec.UsernamePasswordKey, WithUsername("someusername")),
 				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterScope),
 			},
-			{
-				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterGroupScope, spec.SSHKey),
-				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterGroupScope),
-			},
-			{
-				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterGroupScope, spec.SSHKey, WithKnownhosts("somehostes")),
-				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterGroupScope),
-			},
-		},
-	},
-	)
-
-	t.Log("source secret resource acceptance test complete for SSH credential type")
-
-	// Test case for source secret resource with custom recipe.
-	resource.Test(t, resource.TestCase{
-		PreCheck:          testhelper.TestPreCheck(t),
-		ProviderFactories: testhelper.GetTestProviderFactories(testConfig.Provider),
-		CheckDestroy:      nil,
-		Steps: []resource.TestStep{
 			{
 				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterGroupScope, spec.UsernamePasswordKey),
 				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterGroupScope),
 			},
 			{
-				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterGroupScope, spec.UsernamePasswordKey, WithUsername("someusername")),
-				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterGroupScope),
-			},
-			{
 				PreConfig: func() {
-					if testConfig.ScopeHelperResources.Cluster.KubeConfigPath == "" {
-						t.Skip("KUBECONFIG env var is not set for cluster scoped source secret acceptance test")
+					if !found {
+						t.Log("Setting up the updated GET mock responder for cluster group scope...")
+						testConfig.setupHTTPMocksUpdate(t, commonscope.ClusterGroupScope)
 					}
 				},
-				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterScope, spec.UsernamePasswordKey),
-				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterScope),
-			},
-			{
-				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterScope, spec.UsernamePasswordKey, WithUsername("someusername")),
-				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterScope),
+				Config: testConfig.getTestSourceSecretResourceBasicConfigValue(commonscope.ClusterGroupScope, spec.SSHKey, WithKnownhosts("somehosts")),
+				Check:  testConfig.checkSourceSecretResourceAttributes(commonscope.ClusterGroupScope),
 			},
 		},
 	},
 	)
 
-	t.Log("source secret resource acceptance test complete for Username/Password credential type")
+	t.Log("source secret resource acceptance test completed")
 }
 
 func (testConfig *testAcceptanceConfig) getTestSourceSecretResourceBasicConfigValue(scope commonscope.Scope, allowedCredential string, opts ...OperationOption) string {
 	helperBlock, scopeBlock := testConfig.ScopeHelperResources.GetTestSourceSecretResourceHelperAndScope(scope, sourcesecretscope.CredentialTypesAllowed[:])
 	credentialType := testConfig.getTestSourceSecretResourceCredential(allowedCredential, opts...)
+
+	if _, found := os.LookupEnv("ENABLE_REPOCRED_ENV_TEST"); !found {
+		clStr := fmt.Sprintf(`
+	resource "%s" "%s" {
+	 name = "%s"
+	
+	 scope {
+		cluster {
+			name = "%s"
+			management_cluster_name = "attached"
+			provisioner_name = "attached"
+		}
+	 }
+	
+	 spec {
+	   %s
+	 }
+	}
+	`, testConfig.SourceSecretResource, testConfig.SourceSecretResourceVar, testConfig.SourceSecretName, testConfig.ScopeHelperResources.Cluster.Name, credentialType)
+
+		cgStr := fmt.Sprintf(`
+	resource "%s" "%s" {
+	 name = "%s"
+	
+	 scope {
+		cluster_group {
+			name = "%s"
+		}
+	 }
+	
+	 spec {
+	   %s
+	 }
+	}
+	`, testConfig.SourceSecretResource, testConfig.SourceSecretResourceVar, testConfig.SourceSecretName, testConfig.ScopeHelperResources.ClusterGroup.Name, credentialType)
+
+		switch scope {
+		case commonscope.ClusterScope:
+			return clStr
+		case commonscope.ClusterGroupScope:
+			return cgStr
+		default:
+			return ""
+		}
+	}
 
 	return fmt.Sprintf(`
 	%s
@@ -172,7 +241,7 @@ func WithKnownhosts(val string) OperationOption {
 	}
 }
 
-// getTestSourceSecretResourceCredential builds the input block for source secret resource based a recipe.
+// getTestSourceSecretResourceCredential builds the input block for source secret resource.
 // nolint: gosec
 func (testConfig *testAcceptanceConfig) getTestSourceSecretResourceCredential(allowedCredential string, opts ...OperationOption) string {
 	cfg := &OperationConfig{
@@ -253,7 +322,7 @@ func (testConfig *testAcceptanceConfig) verifySourceSecretResourceCreation(scope
 			TLSConfig:        &proxy.TLSConfig{},
 		}
 
-		err := config.Setup()
+		err := getSetupConfig(&config)
 		if err != nil {
 			return errors.Wrap(err, "unable to set the context")
 		}

--- a/internal/resources/sourcesecret/sourcesecret_provider_test.go
+++ b/internal/resources/sourcesecret/sourcesecret_provider_test.go
@@ -29,7 +29,7 @@ func initTestProvider(t *testing.T) *schema.Provider {
 			cluster.ResourceName:      cluster.DataSourceTMCCluster(),
 			clustergroup.ResourceName: clustergroup.DataSourceClusterGroup(),
 		},
-		ConfigureContextFunc: authctx.ProviderConfigureContext,
+		ConfigureContextFunc: getConfigureContextFunc(),
 	}
 	if err := testProvider.InternalValidate(); err != nil {
 		require.NoError(t, err)


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Add mock acceeptance test for source secret

Mock Accep. test -- 
<img width="967" alt="Screenshot 2023-07-16 at 8 13 20 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/57012922/5dcf7f1b-46ec-4c68-88a7-58b91cfb5b66">

Accep. test -- 
<img width="982" alt="Screenshot 2023-07-16 at 8 25 04 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/57012922/eee9df20-6263-400a-ae17-24811591ba43">

