### PR TITLE
Generate manifest with proxy/image-registry secret with cluster support

### DIFF
--- a/examples/resources/cluster/resource_attach_cluster_image_registry.tf
+++ b/examples/resources/cluster/resource_attach_cluster_image_registry.tf
@@ -1,0 +1,50 @@
+# Create Tanzu Mission Control image registry credential and attach cluster entry with the same credential.
+resource "tanzu-mission-control_cluster" "attach_cluster_with_kubeconfig" {
+  management_cluster_name = "attached"     // Default: attached
+  provisioner_name        = "attached"     // Default: attached
+  name                    = "demo-lir" // Required
+
+  attach_k8s_cluster {
+    kubeconfig_file = "<kube-config-path>" // Required
+    description     = "optional description about the kube-config provided"
+  }
+
+  meta {
+    description = "description of the cluster"
+    labels      = { "key" : "value" }
+  }
+
+  spec {
+    cluster_group  = "default" // Default: default
+    image_registry = tanzu-mission-control_credential.img_reg_cred.name
+  }
+
+  ready_wait_timeout = "15m" # Default: waits until 3 min for the cluster to become ready
+}
+
+# Create IMAGE_REGISTRY credential
+resource "tanzu-mission-control_credential" "img_reg_cred" {
+  name = "lir-cred-name"
+
+  meta {
+    description = "credential"
+    labels = {
+      "key1" : "value1",
+    }
+    annotations = {
+      "registry-namespace": "tmc"
+    }
+  }
+
+  spec {
+    capability = "IMAGE_REGISTRY"
+    provider   = "GENERIC_KEY_VALUE"
+    data {
+      key_value {
+        data = {
+          "registry-url" = "dev.registry.tanzu.vmware.com"
+        }
+      }
+    }
+  }
+}

--- a/examples/resources/credential/cluster_image_registry_config.tf
+++ b/examples/resources/credential/cluster_image_registry_config.tf
@@ -8,7 +8,7 @@ resource "tanzu-mission-control_credential" "img_reg_cred" {
       "key1" : "value1",
     }
     annotations = {
-      "repository-path" : "something"
+      "repository-namespace" : "something"
     }
   }
 

--- a/internal/client/cluster/manifest/manifest.go
+++ b/internal/client/cluster/manifest/manifest.go
@@ -1,0 +1,60 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package manifestclient
+
+import (
+	"net/url"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	manifestmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/manifest"
+)
+
+const (
+	apiVersionAndGroup                 = "v1alpha1/clusters:manifest"
+	queryParamKeyManagementClusterName = "fullName.managementClusterName"
+	queryParamKeyProvisionerName       = "fullName.provisionerName"
+)
+
+// New creates a new cluster manifest helper API client.
+func New(transport *transport.Client) ClientService {
+	return &Client{Client: transport}
+}
+
+/*
+Client for cluster manifest helper API.
+*/
+type Client struct {
+	*transport.Client
+}
+
+// ClientService is the interface for Client methods.
+type ClientService interface {
+	ClusterManifestHelperGetManifest(params *clustermodel.VmwareTanzuManageV1alpha1ClusterFullName) (*manifestmodel.VmwareTanzuManageV1alpha1ClusterClusterManifestGetResponse, error)
+}
+
+/*
+ClusterManifestHelperGetManifest gets attach manifest for a cluster.
+*/
+func (a *Client) ClusterManifestHelperGetManifest(params *clustermodel.VmwareTanzuManageV1alpha1ClusterFullName) (*manifestmodel.VmwareTanzuManageV1alpha1ClusterClusterManifestGetResponse, error) {
+	queryParams := url.Values{}
+
+	if params.ManagementClusterName != "" {
+		queryParams.Add(queryParamKeyManagementClusterName, params.ManagementClusterName)
+	}
+
+	if params.ProvisionerName != "" {
+		queryParams.Add(queryParamKeyProvisionerName, params.ProvisionerName)
+	}
+
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup, params.Name).AppendQueryParams(queryParams).String()
+	response := &manifestmodel.VmwareTanzuManageV1alpha1ClusterClusterManifestGetResponse{}
+
+	err := a.Get(requestURL, response)
+
+	return response, err
+}

--- a/internal/client/http_client.go
+++ b/internal/client/http_client.go
@@ -16,6 +16,7 @@ import (
 	gitrepositoryclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/gitrepository"
 	iamclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/iam_policy"
 	kustomizationclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/kustomization"
+	manifestclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/manifest"
 	policyclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/policy"
 	sourcesecretclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/sourcesecret"
 	clustergroupclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/clustergroup"
@@ -96,6 +97,7 @@ func newHTTPClient(httpClient *transport.Client) *TanzuMissionControl {
 		ClusterGroupKustomizationResourceService:      kustomizationclustergroupclient.New(httpClient),
 		ClusterSourcesecretResourceService:            sourcesecretclusterclient.New(httpClient),
 		ClusterGroupSourcesecretResourceService:       sourcesecretclustergroupclient.New(httpClient),
+		ManifestResourceService:                       manifestclient.New(httpClient),
 	}
 }
 
@@ -130,4 +132,5 @@ type TanzuMissionControl struct {
 	ClusterGroupKustomizationResourceService      kustomizationclustergroupclient.ClientService
 	ClusterSourcesecretResourceService            sourcesecretclusterclient.ClientService
 	ClusterGroupSourcesecretResourceService       sourcesecretclustergroupclient.ClientService
+	ManifestResourceService                       manifestclient.ClientService
 }

--- a/internal/models/cluster/manifest/manifest.go
+++ b/internal/models/cluster/manifest/manifest.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package manifestmodel
+
+import "github.com/go-openapi/swag"
+
+// VmwareTanzuManageV1alpha1ClusterClusterManifestGetResponse The response type for getting the attach manifest for a cluster.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.ClusterManifestGetResponse
+type VmwareTanzuManageV1alpha1ClusterClusterManifestGetResponse struct {
+
+	// Attach manifest for the cluster resource.
+	Manifest string `json:"manifest,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterClusterManifestGetResponse) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterClusterManifestGetResponse) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ClusterClusterManifestGetResponse
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/models/cluster/spec.go
+++ b/internal/models/cluster/spec.go
@@ -25,6 +25,10 @@ type VmwareTanzuManageV1alpha1ClusterSpec struct {
 	// to be used for the cluster.
 	ProxyName string `json:"proxyName,omitempty"`
 
+	// Optional image registry is the name of the Image Registry Config
+	// to be used for the cluster.
+	ImageRegistry string `json:"imageRegistry,omitempty"`
+
 	// TKG AWS cluster spec.
 	TkgAws *tkgawsmodel.VmwareTanzuManageV1alpha1ClusterInfrastructureTkgawsSpec `json:"tkgAws,omitempty"`
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,6 +7,7 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/akscluster"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster"

--- a/internal/resources/cluster/cluster_spec_flatten_test.go
+++ b/internal/resources/cluster/cluster_spec_flatten_test.go
@@ -51,6 +51,21 @@ func TestFlattenSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "normal scenario with cluster group, proxy and image registry",
+			input: &clustermodel.VmwareTanzuManageV1alpha1ClusterSpec{
+				ClusterGroupName: "default",
+				ProxyName:        "proxy",
+				ImageRegistry:    "image-registry",
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					clusterGroupKey:      "default",
+					proxyNameKey:         "proxy",
+					imageRegistryNameKey: "image-registry",
+				},
+			},
+		},
 	}
 
 	for _, each := range cases {

--- a/internal/resources/cluster/constants.go
+++ b/internal/resources/cluster/constants.go
@@ -26,4 +26,5 @@ const (
 	attachedValue                  = "attached"
 	distributionKey                = "distribution"
 	versionKey                     = "version"
+	imageRegistryNameKey           = "image_registry"
 )

--- a/internal/resources/cluster/manifest/manifest.go
+++ b/internal/resources/cluster/manifest/manifest.go
@@ -19,14 +19,14 @@ import (
 
 func Create(
 	k8sclient *k8sClient.Client,
-	k8sManifest []byte,
+	k8sManifest string,
 	forceClean bool,
 ) error {
 	if k8sclient == nil {
 		return errors.New("kubernetes client cannot be empty")
 	}
 
-	manifests, err := getManifests(string(k8sManifest))
+	manifests, err := getManifests(k8sManifest)
 	if err != nil {
 		return errors.WithMessage(err, "failure to fetch attach manifests")
 	}

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -151,6 +151,11 @@ var clusterSpec = &schema.Schema{
 				Description: "Optional proxy name is the name of the Proxy Config to be used for the cluster",
 				Optional:    true,
 			},
+			imageRegistryNameKey: {
+				Type:        schema.TypeString,
+				Description: "Optional image registry name is the name of the image registry to be used for the cluster",
+				Optional:    true,
+			},
 			tkgAWSClusterKey:     tkgaws.TkgAWSClusterSpec,
 			tkgServiceVsphereKey: tkgservicevsphere.TkgServiceVsphere,
 			tkgVsphereClusterKey: tkgvsphere.TkgVsphereClusterSpec,
@@ -184,6 +189,10 @@ func constructSpec(d *schema.ResourceData) (spec *clustermodel.VmwareTanzuManage
 		spec.ProxyName = v.(string)
 	}
 
+	if v, ok := specData[imageRegistryNameKey]; ok {
+		spec.ImageRegistry = v.(string)
+	}
+
 	if v, ok := specData[tkgAWSClusterKey]; ok {
 		if v1, ok := v.([]interface{}); ok {
 			spec.TkgAws = tkgaws.ConstructTKGAWSClusterSpec(v1)
@@ -215,6 +224,8 @@ func flattenSpec(spec *clustermodel.VmwareTanzuManageV1alpha1ClusterSpec) (data 
 	flattenSpecData[clusterGroupKey] = spec.ClusterGroupName
 
 	flattenSpecData[proxyNameKey] = spec.ProxyName
+
+	flattenSpecData[imageRegistryNameKey] = spec.ImageRegistry
 
 	if spec.TkgAws != nil {
 		flattenSpecData[tkgAWSClusterKey] = tkgaws.FlattenTKGAWSClusterSpec(spec.TkgAws)
@@ -270,6 +281,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, m interf
 		k8sclient  *k8sClient.Client
 		err        error
 		kubeConfig interface{}
+		manifests  string
 	)
 
 	if v, ok := d.GetOk(attachClusterKey); ok {
@@ -346,14 +358,25 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, m interf
 			Summary:  "Kubernetes cluster's kubeconfig provided. Proceeding to attach the cluster TMC",
 		})
 
-		deploymentManifests, err := manifest.GetK8sManifest(clusterResponse.Cluster.Status.InstallerLink)
-		if err != nil {
-			return append(diags, diag.FromErr(err)...)
+		if clusterResponse.Cluster.Spec.ImageRegistry != "" || clusterResponse.Cluster.Spec.ProxyName != "" {
+			clusterManifest, err := config.TMCConnection.ManifestResourceService.ClusterManifestHelperGetManifest(constructFullname(d))
+			if err != nil {
+				return diag.FromErr(errors.Wrapf(err, "Unable to get manifest (%s) for cluster entry, name : %s", clusterManifest.Manifest, err))
+			}
+
+			manifests = clusterManifest.Manifest
+		} else {
+			deploymentManifest, err := manifest.GetK8sManifest(clusterResponse.Cluster.Status.InstallerLink)
+			if err != nil {
+				return append(diags, diag.FromErr(err)...)
+			}
+
+			manifests = string(deploymentManifest)
 		}
 
 		log.Printf("[INFO] Applying %s cluster's deployment link manifest objects on to kubernetes cluster", constructFullname(d).ToString())
 
-		err = manifest.Create(k8sclient, deploymentManifests, true)
+		err = manifest.Create(k8sclient, manifests, true)
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}

--- a/internal/resources/testing/test_config.go
+++ b/internal/resources/testing/test_config.go
@@ -168,6 +168,50 @@ const testAttachClusterWithKubeConfigScript = `
 	}
 `
 
+const testAttachClusterWithKubeConfigScriptImageRegistry = `
+	resource {{.ResourceName}} {{.ResourceNameVar}} {
+		management_cluster_name = "attached"
+		provisioner_name        = "attached"
+		name                    = "{{.Name}}"
+
+		attach_k8s_cluster {
+			kubeconfig_file = "{{.KubeConfigPath}}"
+			description     = "optional description about the kube-config provided"
+		}
+
+		{{.Meta}}
+
+		spec {
+			cluster_group = "default"
+			image_registry = "{{.ImageRegistry}}"
+		}
+
+		ready_wait_timeout = "3m"
+	}
+`
+
+const testAttachClusterWithKubeConfigScriptProxy = `
+	resource {{.ResourceName}} {{.ResourceNameVar}} {
+		management_cluster_name = "attached"
+		provisioner_name        = "attached"
+		name                    = "{{.Name}}"
+
+		attach_k8s_cluster {
+			kubeconfig_file = "{{.KubeConfigPath}}"
+			description     = "optional description about the kube-config provided"
+		}
+
+		{{.Meta}}
+
+		spec {
+			cluster_group = "default"
+			proxy         = "{{.Proxy}}"
+		}
+
+		ready_wait_timeout = "3m"
+	}
+`
+
 const testDataSourceAttachClusterScript = `
 	resource {{.ResourceName}} {{.ResourceNameVar}} {
 		management_cluster_name = "attached"

--- a/internal/resources/testing/test_helper.go
+++ b/internal/resources/testing/test_helper.go
@@ -17,6 +17,8 @@ type AcceptanceTestType int
 const (
 	AttachClusterType AcceptanceTestType = iota
 	AttachClusterTypeWithKubeConfig
+	AttachClusterTypeWithKubeconfigImageRegistry
+	AttachClusterTypeWithKubeconfigProxy
 	TkgAWSCluster
 	TkgsCluster
 	TkgVsphereCluster
@@ -69,6 +71,8 @@ type TestAcceptanceConfig struct {
 	CredentialName           string
 	OrgID                    string
 	ClusterGroupName         string
+	ImageRegistry            string
+	Proxy                    string
 }
 
 func WithClusterName(name string) TestAcceptanceOption {
@@ -158,6 +162,24 @@ func WithKubeConfig() TestAcceptanceOption {
 		config.KubeConfigPath = os.Getenv("KUBECONFIG")
 		config.AccTestType = AttachClusterTypeWithKubeConfig
 		config.TemplateData = testAttachClusterWithKubeConfigScript
+	}
+}
+
+func WithKubeConfigImageRegistry() TestAcceptanceOption {
+	return func(config *TestAcceptanceConfig) {
+		config.KubeConfigPath = os.Getenv("KUBECONFIG")
+		config.ImageRegistry = os.Getenv("IMAGE_REGISTRY")
+		config.AccTestType = AttachClusterTypeWithKubeconfigImageRegistry
+		config.TemplateData = testAttachClusterWithKubeConfigScriptImageRegistry
+	}
+}
+
+func WithKubeConfigProxy() TestAcceptanceOption {
+	return func(config *TestAcceptanceConfig) {
+		config.KubeConfigPath = os.Getenv("KUBECONFIG")
+		config.Proxy = os.Getenv("PROXY")
+		config.AccTestType = AttachClusterTypeWithKubeconfigProxy
+		config.TemplateData = testAttachClusterWithKubeConfigScriptProxy
 	}
 }
 


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Generate manifest with proxy/image-registry secret with cluster support.

Manifest with image registry secret is generated using the `GetManifest` API call.

```
apiVersion: v1
kind: Secret
metadata:
  name: tmc-imagepull-secret
  namespace: vmware-system-tmc
  labels:
    tmc.cloud.vmware.com/managed: "true"
data:
  ca-cert: "cert"
```

![image](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/47659349/3d6ada4d-379e-431e-8998-ac722c3ebb59)

Acceptance test:

![image](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/47659349/85ea07b6-5b0e-46a3-8ec9-4e839898bc80)


3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->