### PR TITLE
Fix update aks cluster metadata

### DIFF
--- a/internal/resources/akscluster/akscluster_mapper.go
+++ b/internal/resources/akscluster/akscluster_mapper.go
@@ -437,6 +437,7 @@ func ToAKSClusterMap(cluster *models.VmwareTanzuManageV1alpha1AksCluster, nodepo
 	data[SubscriptionIDKey] = cluster.FullName.SubscriptionID
 	data[ResourceGroupNameKey] = cluster.FullName.ResourceGroupName
 	data[NameKey] = cluster.FullName.Name
+	data[common.MetaKey] = cluster.Meta
 	data[clusterSpecKey] = toClusterSpecMap(cluster.Spec, nodepools)
 
 	return data

--- a/internal/resources/akscluster/akscluster_mapper_test.go
+++ b/internal/resources/akscluster/akscluster_mapper_test.go
@@ -14,6 +14,7 @@ import (
 
 	models "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/akscluster"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/akscluster"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster"
 )
 
 func Test_ConstructAKSCluster(t *testing.T) {
@@ -37,14 +38,14 @@ func Test_FlattenToMap_fullSpec(t *testing.T) {
 	testNodepool := []*models.VmwareTanzuManageV1alpha1AksclusterNodepoolNodepool{aTestNodePool()}
 	expected := aTestClusterDataMap()
 
-	got := akscluster.ToAKSClusterMap(testCluster, testNodepool)
-	assert.Equal(t, expected, got)
+	got := akscluster.ToAKSClusterMap(testCluster, testNodepool).(map[string]any)
+	assert.Equal(t, expected[cluster.SpecKey], got[cluster.SpecKey])
 }
 
 func Test_FlattenToMap_nilNodepools(t *testing.T) {
 	testCluster := aTestCluster()
 	expected := aTestClusterDataMap(withoutNodepools)
 
-	got := akscluster.ToAKSClusterMap(testCluster, nil)
-	assert.Equal(t, expected, got)
+	got := akscluster.ToAKSClusterMap(testCluster, nil).(map[string]any)
+	assert.Equal(t, expected[cluster.SpecKey], got[cluster.SpecKey])
 }

--- a/internal/resources/akscluster/helpers_test.go
+++ b/internal/resources/akscluster/helpers_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -79,7 +81,11 @@ func aTestCluster(w ...clusterWither) *models.VmwareTanzuManageV1alpha1AksCluste
 			Name:              "test-cluster",
 		},
 		Meta: &objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta{
-			UID: "test-uid",
+			Annotations:  map[string]string{},
+			CreationTime: strfmt.DateTime{},
+			Labels:       map[string]string{"label": "value"},
+			UID:          "test-uid",
+			UpdateTime:   strfmt.DateTime{},
 		},
 		Spec: &models.VmwareTanzuManageV1alpha1AksclusterSpec{
 			ClusterGroupName: "my-cluster-group",
@@ -190,6 +196,14 @@ func withDNSPrefix(prefix string) mapWither {
 	}
 }
 
+func withLabels(label, value string) mapWither {
+	return func(m map[string]any) {
+		metadatas := m["meta"].([]any)
+		metadata := metadatas[0].(map[string]any)
+		metadata["labels"] = map[string]any{label: value}
+	}
+}
+
 func withNodepools(nps []any) mapWither {
 	return func(m map[string]any) {
 		specs := m["spec"].([]any)
@@ -234,6 +248,12 @@ func aTestClusterDataMap(w ...mapWither) map[string]any {
 		"subscription_id": "sub-id",
 		"resource_group":  "resource-group",
 		"name":            "test-cluster",
+		"meta": []any{map[string]any{
+			"uid": "test-uid",
+			"labels": map[string]any{
+				"label": "value",
+			},
+		}},
 		"spec": []any{map[string]any{
 			"cluster_group": "my-cluster-group",
 			"proxy":         "my-proxy",

--- a/internal/resources/akscluster/resource_akscluster_test.go
+++ b/internal/resources/akscluster/resource_akscluster_test.go
@@ -264,6 +264,20 @@ func (s *UpdateClusterTestSuite) Test_resourceClusterUpdate_updateClusterConfig(
 	s.Assert().Nil(s.mocks.nodepoolClient.UpdatedNodepoolWasCalledWith)
 }
 
+func (s *UpdateClusterTestSuite) Test_resourceClusterUpdate_updateClusterMetadata() {
+	originalCluster := aTestClusterDataMap(withLabels("label", "value1"))
+	updatedCluster := aTestClusterDataMap(withLabels("label", "value2"))
+	d := dataDiffFrom(s.T(), originalCluster, updatedCluster)
+	expected := aTestCluster()
+	expected.Meta.Labels = map[string]string{"label": "value2"}
+
+	result := s.aksClusterResource.UpdateContext(s.ctx, d, s.config)
+
+	s.Assert().False(result.HasError())
+	s.Assert().Equal(expected, s.mocks.clusterClient.AksUpdateClusterWasCalledWith)
+	s.Assert().Nil(s.mocks.nodepoolClient.UpdatedNodepoolWasCalledWith)
+}
+
 func (s *UpdateClusterTestSuite) Test_resourceClusterUpdate_updateNodepool() {
 	originalNodepools := []any{aTestNodepoolDataMap(withNodepoolCount(1))}
 	updatedNodepools := []any{aTestNodepoolDataMap(withNodepoolCount(5))}


### PR DESCRIPTION
1. **What this PR does / why we need it**:
Updates the data mappers to compute updates to metadata information.

3. **Which issue(s) this PR fixes**
Fixes bug preventing metadata from being updated

4. **Additional information**
This update will allow you to set the Label and Annotation metadata fields


6. **Special notes for your reviewer**
unit tests   

<img width="903" alt="image" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/31905979/45c4ada7-0ea7-476a-9530-3243f79c7da8">

acceptance test.  

<img width="401" alt="image" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/31905979/3ee7f21a-2e8f-42c2-8d1c-7c4d96d56113">
