### PR TITLE
EKS Cluster Ready Wait Timeout now defaults to 30m

### DIFF
--- a/internal/resources/ekscluster/data_source.go
+++ b/internal/resources/ekscluster/data_source.go
@@ -99,8 +99,9 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 	default:
 		timeoutDuration, parseErr := time.ParseDuration(timeoutValueData)
 		if parseErr != nil {
-			log.Printf("[INFO] unable to prase the duration value for the key %s. Defaulting to 5 minutes(5m)"+
-				" Please refer to 'https://pkg.go.dev/time#ParseDuration' for providing the right value", waitKey)
+			defaultTimeoutInMinutes := defaultTimeout / time.Minute
+			log.Printf("[INFO] unable to parse the duration value for the key %s. Defaulting to %d minutes(%dm)"+
+				" Please refer to 'https://pkg.go.dev/time#ParseDuration' for providing the right value", waitKey, defaultTimeoutInMinutes, defaultTimeoutInMinutes)
 
 			timeoutDuration = defaultTimeout
 		}

--- a/internal/resources/ekscluster/resource_ekscluster.go
+++ b/internal/resources/ekscluster/resource_ekscluster.go
@@ -31,7 +31,7 @@ type (
 
 var ignoredTagsPrefix = "tmc.cloud.vmware.com/"
 
-const defaultTimeout = 3 * time.Minute
+const defaultTimeout = 30 * time.Minute
 
 func ResourceTMCEKSCluster() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION
1. **What this PR does / why we need it**:
Sets the default ready wait timeout to 30 minutes instead of 3 minutes.
The existing 3 minutes is too short for most real world situations.
See Issue #181

2. **Which issue(s) this PR fixes**
Fixes #181

3. **Additional information**
![Screenshot 2023-08-10 at 4 08 13 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/16089977/452ab2a5-9d4b-4152-86c2-9d074c074146)

4. **Special notes for your reviewer**
