### PR TITLE
Validate network config for aks cluster

### DIFF
--- a/docs/data-sources/akscluster.md
+++ b/docs/data-sources/akscluster.md
@@ -102,13 +102,13 @@ Required:
 
 Optional:
 
-- `dns_service_ip` (String) IP address assigned to the Kubernetes DNS service
+- `dns_service_ip` (String) IP address assigned to the Kubernetes DNS service. This key can only be set when the network_config.network_plugin key is set to 'azure'.
 - `docker_bridge_cidr` (String) A CIDR notation IP range assigned to the Docker bridge network
 - `load_balancer_sku` (String) Load balancer SKU
-- `network_plugin` (String) Network plugin
+- `network_plugin` (String) Network plugin. Set the value of this key to 'azure' if you want to specify values for network_config.dns_service_ip and/or network_config.service_cidr.
 - `network_policy` (String) Network policy
 - `pod_cidr` (List of String) CIDR notation IP ranges from which to assign pod IPs
-- `service_cidr` (List of String) CIDR notation IP ranges from which to assign service cluster IP
+- `service_cidr` (List of String) CIDR notation IP ranges from which to assign service cluster IP. This key can only be set when the network_config.network_plugin key is set to 'azure'.
 
 
 <a id="nestedblock--spec--config--access_config"></a>

--- a/docs/resources/akscluster.md
+++ b/docs/resources/akscluster.md
@@ -143,13 +143,13 @@ Required:
 
 Optional:
 
-- `dns_service_ip` (String) IP address assigned to the Kubernetes DNS service
+- `dns_service_ip` (String) IP address assigned to the Kubernetes DNS service. This key can only be set when the network_config.network_plugin key is set to 'azure'.
 - `docker_bridge_cidr` (String) A CIDR notation IP range assigned to the Docker bridge network
 - `load_balancer_sku` (String) Load balancer SKU
-- `network_plugin` (String) Network plugin
+- `network_plugin` (String) Network plugin. Set the value of this key to 'azure' if you want to specify values for network_config.dns_service_ip and/or network_config.service_cidr.
 - `network_policy` (String) Network policy
 - `pod_cidr` (List of String) CIDR notation IP ranges from which to assign pod IPs
-- `service_cidr` (List of String) CIDR notation IP ranges from which to assign service cluster IP
+- `service_cidr` (List of String) CIDR notation IP ranges from which to assign service cluster IP. This key can only be set when the network_config.network_plugin key is set to 'azure'.
 
 
 <a id="nestedblock--spec--config--access_config"></a>

--- a/internal/resources/akscluster/akscluster_mapper_test.go
+++ b/internal/resources/akscluster/akscluster_mapper_test.go
@@ -19,12 +19,26 @@ import (
 func Test_ConstructAKSCluster(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, akscluster.ClusterSchema, aTestClusterDataMap())
 
-	result := akscluster.ConstructCluster(d)
+	result, _ := akscluster.ConstructCluster(d)
 	expected := aTestCluster()
 
 	assert.NotNil(t, result, "no request created")
 	assert.Equal(t, expected.FullName, result.FullName, "unexpected full name")
 	assert.Equal(t, expected.Spec, result.Spec, "unexpected spec")
+}
+
+func Test_ConstructAKSCluster_withInvalidNetworkConfig(t *testing.T) {
+	tests := []*schema.ResourceData{
+		schema.TestResourceDataRaw(t, akscluster.ClusterSchema, aTestClusterDataMap(withNetworkPlugin("kubenet"))),
+		schema.TestResourceDataRaw(t, akscluster.ClusterSchema, aTestClusterDataMap(withNetworkPlugin("kubenet"), withoutNetworkDNSServiceIP)),
+		schema.TestResourceDataRaw(t, akscluster.ClusterSchema, aTestClusterDataMap(withNetworkPlugin("kubenet"), withoutNetworkServiceCIDR)),
+	}
+
+	for _, d := range tests {
+		_, err := akscluster.ConstructCluster(d)
+		assert.NotNil(t, err)
+		assert.Equal(t, err.Error(), "can not set network_config.dns_service_ip or network_config.service_cidr when network_config.network_plugin is set to kubenet")
+	}
 }
 
 func Test_FlattenToMap_nilSpec(t *testing.T) {

--- a/internal/resources/akscluster/helpers_test.go
+++ b/internal/resources/akscluster/helpers_test.go
@@ -190,6 +190,38 @@ func withDNSPrefix(prefix string) mapWither {
 	}
 }
 
+func withNetworkPlugin(plugin string) mapWither {
+	return func(m map[string]any) {
+		specs := m["spec"].([]any)
+		spec := specs[0].(map[string]any)
+		configs := spec["config"].([]any)
+		config := configs[0].(map[string]any)
+		networks := config["network_config"].([]any)
+		network := networks[0].(map[string]any)
+		network["network_plugin"] = plugin
+	}
+}
+
+func withoutNetworkDNSServiceIP(m map[string]any) {
+	specs := m["spec"].([]any)
+	spec := specs[0].(map[string]any)
+	configs := spec["config"].([]any)
+	config := configs[0].(map[string]any)
+	networks := config["network_config"].([]any)
+	network := networks[0].(map[string]any)
+	delete(network, "dns_service_ip")
+}
+
+func withoutNetworkServiceCIDR(m map[string]any) {
+	specs := m["spec"].([]any)
+	spec := specs[0].(map[string]any)
+	configs := spec["config"].([]any)
+	config := configs[0].(map[string]any)
+	networks := config["network_config"].([]any)
+	network := networks[0].(map[string]any)
+	delete(network, "service_cidr")
+}
+
 func withNodepools(nps []any) mapWither {
 	return func(m map[string]any) {
 		specs := m["spec"].([]any)

--- a/internal/resources/akscluster/resource_akscluster.go
+++ b/internal/resources/akscluster/resource_akscluster.go
@@ -182,7 +182,11 @@ func validate(nodepools []*models.VmwareTanzuManageV1alpha1AksclusterNodepoolNod
 // createOrUpdateCluster creates an AKS cluster in TMC.  It is possible the cluster already exists in which case the
 // existing cluster is updated with any node pools defined in the configuration.
 func createOrUpdateCluster(data *schema.ResourceData, client akscluster.ClientService) error {
-	cluster := ConstructCluster(data)
+	cluster, cErr := ConstructCluster(data)
+	if cErr != nil {
+		return cErr
+	}
+
 	clusterReq := &models.VmwareTanzuManageV1alpha1AksclusterCreateAksClusterRequest{AksCluster: cluster}
 	createResp, err := client.AksClusterResourceServiceCreate(clusterReq)
 
@@ -215,7 +219,11 @@ func getExistingCluster(data *schema.ResourceData, client akscluster.ClientServi
 }
 
 func updateClusterConfig(ctx context.Context, data *schema.ResourceData, clusterResp *models.VmwareTanzuManageV1alpha1AksclusterGetAksClusterResponse, tc authctx.TanzuContext) error {
-	cluster := ConstructCluster(data)
+	cluster, cErr := ConstructCluster(data)
+	if cErr != nil {
+		return cErr
+	}
+
 	cluster.Meta = clusterResp.AksCluster.Meta
 	updateReq := &models.VmwareTanzuManageV1alpha1AksclusterUpdateAksClusterRequest{AksCluster: cluster}
 

--- a/internal/resources/akscluster/resource_akscluster_test.go
+++ b/internal/resources/akscluster/resource_akscluster_test.go
@@ -559,7 +559,7 @@ func (s *ImportClusterTestSuite) Test_resourceClusterImport() {
 
 	s.Assert().NoError(err)
 	s.Assert().Len(result, 1)
-	cluster := akscluster.ConstructCluster(result[0])
+	cluster, _ := akscluster.ConstructCluster(result[0])
 	s.Assert().Equal(cluster.FullName.Name, "test-cluster")
 	s.Assert().Equal(cluster.FullName.CredentialName, "test-cred")
 	s.Assert().Equal(cluster.FullName.SubscriptionID, "sub-id")

--- a/internal/resources/akscluster/schema.go
+++ b/internal/resources/akscluster/schema.go
@@ -310,7 +310,7 @@ var NetworkConfig = &schema.Resource{
 		},
 		networkPluginKey: {
 			Type:        schema.TypeString,
-			Description: "Network plugin",
+			Description: "Network plugin. Set the value of this key to 'azure' if you want to specify values for network_config.dns_service_ip and/or network_config.service_cidr.",
 			ForceNew:    true,
 			Optional:    true,
 			Computed:    true,
@@ -323,7 +323,7 @@ var NetworkConfig = &schema.Resource{
 		},
 		dnsServiceIPKey: {
 			Type:        schema.TypeString,
-			Description: "IP address assigned to the Kubernetes DNS service",
+			Description: "IP address assigned to the Kubernetes DNS service. This key can only be set when the network_config.network_plugin key is set to 'azure'.",
 			ForceNew:    true,
 			Optional:    true,
 			Computed:    true,
@@ -347,7 +347,7 @@ var NetworkConfig = &schema.Resource{
 		},
 		serviceCidrKey: {
 			Type:        schema.TypeList,
-			Description: "CIDR notation IP ranges from which to assign service cluster IP",
+			Description: "CIDR notation IP ranges from which to assign service cluster IP. This key can only be set when the network_config.network_plugin key is set to 'azure'.",
 			ForceNew:    true,
 			Optional:    true,
 			Computed:    true,


### PR DESCRIPTION
When network_plugin key is set to kubenet, then setting dns_service_ip and/or service_cidr keys is not supported / allowed and will now return an error during terraform apply.

1. **What this PR does / why we need it**:

There are several network settings the API always allows you to pass, however these fields are ignored if the network type is not azure. This results in a situation where the Terraform state does not match the provision infrastructure as some values that were passed were ultimately ignored.

Thus this MR adds validation logic to ensure that the 'dns_service_ip' and/or 'service_cidr' keys are only set when the 'network_plugin' key is set to 'azure'. If they are set when they should not be, then terraform apply fails with an error message.

2. **Which issue(s) this PR fixes**

3. **Additional information**

Unit tested and tested by running 'terraform apply' with both valid and invalid network configs.

![Screenshot 2023-08-14 at 6 29 34 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/16089977/3afc2e64-1717-4324-b4c5-4e87833bca5a)

Also updated the aks documentation to highlight this requirement.

4. **Special notes for your reviewer**
