### PR TITLE
Fix the token expiry issue in resources with ready_wait_timeout option for TMC self managed

### DIFF
--- a/internal/authctx/helper.go
+++ b/internal/authctx/helper.go
@@ -111,6 +111,16 @@ var selfManagedAuthSchema = &schema.Schema{
 	},
 }
 
+var RefreshUserAuthContext = func(config *TanzuContext, refreshCondition func(error) bool, err error) {
+	if refreshCondition(err) {
+		if config.IsSelfManaged() {
+			refreshSMUserAuthCtx(config)
+			return
+		}
+		refreshSaaSUserAuthCtx(config)
+	}
+}
+
 func ProviderConfigureContext(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	config := TanzuContext{
 		TLSConfig:   &proxy.TLSConfig{},

--- a/internal/authctx/saas.go
+++ b/internal/authctx/saas.go
@@ -135,17 +135,6 @@ func getSaaSUserAuthCtx(vmCloudEndPoint, cspToken string, proxyConfig *proxy.TLS
 	return md, nil
 }
 
-var RefreshUserAuthContext = func(config *TanzuContext, refreshCondition func(error) bool, err error) {
-	if config.IsSelfManaged() {
-		// For self-managed the refresh happens before every request is made
-		return
-	}
-
-	if refreshCondition(err) {
-		refreshSaaSUserAuthCtx(config)
-	}
-}
-
 func refreshSaaSUserAuthCtx(config *TanzuContext) {
 	md, _ := getSaaSUserAuthCtx(config.VMWCloudEndPoint, config.Token, config.TLSConfig)
 	for key, value := range md {

--- a/internal/authctx/selfmanaged.go
+++ b/internal/authctx/selfmanaged.go
@@ -229,3 +229,10 @@ func (s *smSession) getAuthCodeURL() string {
 
 	return s.sharedOauthConfig.AuthCodeURL(s.stateVal.String(), opts...)
 }
+
+func refreshSMUserAuthCtx(config *TanzuContext) {
+	md, _ := getSMUserAuthCtx(config.VMWCloudEndPoint, config.SMUsername, config.Token)
+	for key, value := range md {
+		config.TMCConnection.Headers.Set(key, value)
+	}
+}


### PR DESCRIPTION
1. **What this PR does / why we need it**:
    In TMC self managed the token is short lived for 2m, so we need to refresh the token once it expires in cases where the terraform apply waits for the resource creation/deletion/updation else if the operation spans beyond 2 min then we will end up hitting 401 unauthorised err for any resource.

3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes # Issue reported over Jira


4. **Additional information**

- Validated the fix against TMC SM for cluster create
![Screenshot 2023-08-17 at 11 31 48 AM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/80737804/35e907a6-1fee-4be9-b8d0-9265310e806c)

- TMC SM for cluster update
![Screenshot 2023-08-17 at 11 44 08 AM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/80737804/77718c9d-f241-49e0-9ed2-73fcc6b5b77c)

- TMC SM for cluster delete 
![Screenshot 2023-08-17 at 11 43 07 AM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/80737804/5a11e991-bb2e-45b1-bec4-4fb012a9082b)


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->