### PR TITLE
Suppress diff during terraform plan for aks when features are disabled

### DIFF
--- a/internal/resources/akscluster/schema.go
+++ b/internal/resources/akscluster/schema.go
@@ -394,18 +394,27 @@ var AddonConfig = &schema.Resource{
 			Description: "Keyvault secrets provider addon",
 			Optional:    true,
 			Elem:        AzureKeyvaulSecretsProviderConfig,
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				return suppressConfig(k, d)
+			},
 		},
 		monitorAddonConfigKey: {
 			Type:        schema.TypeList,
 			Description: "Monitor addon",
 			Optional:    true,
 			Elem:        MonitorAddonConfig,
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				return suppressConfig(k, d)
+			},
 		},
 		azurePolicyAddonConfigKey: {
 			Type:        schema.TypeList,
 			Description: "Azure policy addon",
 			Optional:    true,
 			Elem:        AzurePolicyAddonConfig,
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				return suppressConfig(k, d)
+			},
 		},
 	},
 }
@@ -602,6 +611,9 @@ var NodepoolSpecSchema = &schema.Schema{
 				Optional:    true,
 				MaxItems:    1,
 				Elem:        AutoScaleConfig,
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					return suppressConfig(k, d)
+				},
 			},
 			upgradeConfigKey: {
 				Type:        schema.TypeList,
@@ -660,4 +672,15 @@ var AutoScaleConfig = &schema.Resource{
 			Optional:    true,
 		},
 	},
+}
+
+func suppressConfig(key string, resourceData *schema.ResourceData) bool {
+	lastDotIndex := strings.LastIndex(key, ".")
+	if lastDotIndex == -1 {
+		return false
+	}
+
+	key = key[:lastDotIndex]
+
+	return resourceData.Get(key+".enable") == false
 }


### PR DESCRIPTION
1. **What this PR does / why we need it**:

For terraform spec where a feature config has a sub-key called 'enable' if that key's value is false, then that feature will be ignored during the apply. Thus we should suppress it during the plan step.

2. **Which issue(s) this PR fixes**

We don't want to see diffs on features that are disabled, so that terraform plans correctly describe the actions that will be take.

As an example given:
```
auto_scaling_config {
  enable    = false
  max_count = 3
  min_count = 1
}
```
any changes to max_count or min_count should be ignored since the feature is marked as disabled and updates to min and max count will have no effect. Thus there is no value in showing them in the diff generated by terraform's plan step.

3. **Additional information**

Tested via executing 'terraform plan' for an aks cluster.

Given a terraform file, where the enable key is set to true, the following is the diff from terraform plan:

![Screenshot 2023-08-17 at 5 37 23 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/16089977/e46c28bf-3989-4a5a-99ff-6701450a308d)

![Screenshot 2023-08-17 at 5 37 37 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/16089977/92d5216f-4490-4ef5-a17a-5f5186966f00)

With this change to the schema validation, when the enable keys are set to false the following diff is generated:

![Screenshot 2023-08-18 at 12 39 33 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/16089977/3dc0f778-c659-41bb-8ec1-0646ab78d680)

4. **Special notes for your reviewer**
