### PR TITLE
fixes for k8s service account iam policy

### DIFF
--- a/docs/resources/iam_policy.md
+++ b/docs/resources/iam_policy.md
@@ -172,6 +172,29 @@ resource "tanzu-mission-control_iam_policy" "workspace_scoped_iam_policy" {
 }
 ```
 
+```terraform
+/*
+ Workspace scoped Tanzu Mission Control IAM policy using a K8s Service Account
+ This resource is applied on a workspace to provision the role bindings on the associated workspace.
+ The defined scope block can be updated to change the access policy's scope.
+ */
+resource "tanzu-mission-control_iam_policy" "workspace_scoped_iam_policy" {
+  scope {
+    workspace {
+      name = "tf-workspace"
+    }
+  }
+
+  role_bindings {
+    role = "workspace.edit"
+    subjects {
+      name = "namespace:serviceaccountname"
+      kind = "K8S_SERVICEACCOUNT"
+    }
+  }
+}
+```
+
 ## Namespace scoped IAM Policy
 
 ### Example Usage

--- a/docs/resources/iam_policy.md
+++ b/docs/resources/iam_policy.md
@@ -235,7 +235,7 @@ Required:
 
 Required:
 
-- `kind` (String) Subject type, having one of the subject types: USER or GROUP
+- `kind` (String) Subject type, having one of the subject types: USER, GROUP, or K8S_SERVICEACCOUNT
 - `name` (String) Subject name: allow max characters for email - 320 characters.
 
 

--- a/internal/models/iam_policy/policy_subject_kind.go
+++ b/internal/models/iam_policy/policy_subject_kind.go
@@ -39,6 +39,9 @@ const (
 	// VmwareTanzuCoreV1alpha1PolicySubjectKindK8SSERVICEACCOUNT captures enum value "K8S_SERVICEACCOUNT".
 	VmwareTanzuCoreV1alpha1PolicySubjectKindK8SSERVICEACCOUNT VmwareTanzuCoreV1alpha1PolicySubjectKind = "K8S_SERVICEACCOUNT"
 
+	// VmwareTanzuCoreV1alpha1PolicySubjectKindSERVICEACCOUNT captures enum value "SERVICEACCOUNT".
+	VmwareTanzuCoreV1alpha1PolicySubjectKindSERVICEACCOUNT VmwareTanzuCoreV1alpha1PolicySubjectKind = "SERVICEACCOUNT"
+
 	// VmwareTanzuCoreV1alpha1PolicySubjectKindUSER captures enum value "USER".
 	VmwareTanzuCoreV1alpha1PolicySubjectKindUSER VmwareTanzuCoreV1alpha1PolicySubjectKind = "USER"
 )

--- a/internal/models/iam_policy/policy_subject_kind.go
+++ b/internal/models/iam_policy/policy_subject_kind.go
@@ -36,8 +36,8 @@ const (
 	// VmwareTanzuCoreV1alpha1PolicySubjectKindGROUP captures enum value "GROUP".
 	VmwareTanzuCoreV1alpha1PolicySubjectKindGROUP VmwareTanzuCoreV1alpha1PolicySubjectKind = "GROUP"
 
-	// VmwareTanzuCoreV1alpha1PolicySubjectKindSERVICEACCOUNT captures enum value "SERVICEACCOUNT".
-	VmwareTanzuCoreV1alpha1PolicySubjectKindSERVICEACCOUNT VmwareTanzuCoreV1alpha1PolicySubjectKind = "SERVICEACCOUNT"
+	// VmwareTanzuCoreV1alpha1PolicySubjectKindK8SSERVICEACCOUNT captures enum value "K8S_SERVICEACCOUNT".
+	VmwareTanzuCoreV1alpha1PolicySubjectKindK8SSERVICEACCOUNT VmwareTanzuCoreV1alpha1PolicySubjectKind = "K8S_SERVICEACCOUNT"
 
 	// VmwareTanzuCoreV1alpha1PolicySubjectKindUSER captures enum value "USER".
 	VmwareTanzuCoreV1alpha1PolicySubjectKindUSER VmwareTanzuCoreV1alpha1PolicySubjectKind = "USER"
@@ -48,7 +48,7 @@ var vmwareTanzuCoreV1alpha1PolicySubjectKindEnum []interface{}
 
 func init() {
 	var res []VmwareTanzuCoreV1alpha1PolicySubjectKind
-	if err := json.Unmarshal([]byte(`["KIND_UNSPECIFIED","GROUP","SERVICEACCOUNT","USER"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["KIND_UNSPECIFIED","GROUP","K8S_SERVICEACCOUNT","USER"]`), &res); err != nil {
 		panic(err)
 	}
 

--- a/internal/resources/iampolicy/constants.go
+++ b/internal/resources/iampolicy/constants.go
@@ -33,4 +33,4 @@ const (
 	namespaceScope
 )
 
-const roleSubjectDelimiter = ","
+const roleSubjectDelimiter = ";"

--- a/internal/resources/iampolicy/constants.go
+++ b/internal/resources/iampolicy/constants.go
@@ -33,4 +33,4 @@ const (
 	namespaceScope
 )
 
-const roleSubjectDelimiter = "_"
+const roleSubjectDelimiter = ","

--- a/internal/resources/iampolicy/role_binding_test.go
+++ b/internal/resources/iampolicy/role_binding_test.go
@@ -65,7 +65,7 @@ func TestRoleBindingListToUpdate(t *testing.T) {
 		{
 			description: "check for normal scenario of an entry in map",
 			input: &map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 			expected: []*iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDelta{
 				{
@@ -113,11 +113,11 @@ func TestRBOpForUpdate(t *testing.T) {
 				},
 			},
 			inputMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 			action: iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
 			expectedMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
 			},
 		},
 		{
@@ -134,11 +134,11 @@ func TestRBOpForUpdate(t *testing.T) {
 				},
 			},
 			inputMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 			action: iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
 			expectedMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
 			},
 		},
 		{
@@ -155,11 +155,11 @@ func TestRBOpForUpdate(t *testing.T) {
 				},
 			},
 			inputMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 			action: iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			expectedMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 		},
 		{
@@ -176,11 +176,11 @@ func TestRBOpForUpdate(t *testing.T) {
 				},
 			},
 			inputMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
 			},
 			action: iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			expectedMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin_test_USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
+				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
 			},
 		},
 	}

--- a/internal/resources/iampolicy/role_binding_test.go
+++ b/internal/resources/iampolicy/role_binding_test.go
@@ -65,7 +65,7 @@ func TestRoleBindingListToUpdate(t *testing.T) {
 		{
 			description: "check for normal scenario of an entry in map",
 			input: &map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 			expected: []*iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDelta{
 				{
@@ -113,11 +113,11 @@ func TestRBOpForUpdate(t *testing.T) {
 				},
 			},
 			inputMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 			action: iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
 			expectedMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
 			},
 		},
 		{
@@ -134,11 +134,11 @@ func TestRBOpForUpdate(t *testing.T) {
 				},
 			},
 			inputMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 			action: iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
 			expectedMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
 			},
 		},
 		{
@@ -155,11 +155,11 @@ func TestRBOpForUpdate(t *testing.T) {
 				},
 			},
 			inputMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 			action: iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			expectedMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			},
 		},
 		{
@@ -176,11 +176,11 @@ func TestRBOpForUpdate(t *testing.T) {
 				},
 			},
 			inputMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeDELETE,
 			},
 			action: iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeADD,
 			expectedMap: map[string]iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpType{
-				"cluster.admin,test,USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
+				"cluster.admin;test;USER": iammodel.VmwareTanzuCoreV1alpha1PolicyBindingDeltaOpTypeOPTYPEUNSPECIFIED,
 			},
 		},
 	}

--- a/internal/resources/iampolicy/role_bindings.go
+++ b/internal/resources/iampolicy/role_bindings.go
@@ -45,7 +45,7 @@ var roleBinding = &schema.Schema{
 							Type:         schema.TypeString,
 							Description:  "Subject type, having one of the subject types: USER or GROUP",
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"USER", "GROUP"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"USER", "GROUP", "K8S_SERVICEACCOUNT"}, false),
 						},
 					},
 				},


### PR DESCRIPTION
1. **What this PR does / why we need it**:

adding support for K8S_SERVICEACCOUNT as a type for IAM policy

2. **Which issue(s) this PR fixes**

fixes 
https://github.com/vmware/terraform-provider-tanzu-mission-control/issues/242

