### PR TITLE
Update I am policy resources doc as per the changes in PR#243

### DIFF
--- a/docs/resources/iam_policy.md
+++ b/docs/resources/iam_policy.md
@@ -172,6 +172,10 @@ resource "tanzu-mission-control_iam_policy" "workspace_scoped_iam_policy" {
 }
 ```
 
+## Workspace scoped IAM Policy using a K8s Service Account
+
+### Example Usage
+
 ```terraform
 /*
  Workspace scoped Tanzu Mission Control IAM policy using a K8s Service Account
@@ -184,7 +188,6 @@ resource "tanzu-mission-control_iam_policy" "workspace_scoped_iam_policy" {
       name = "tf-workspace"
     }
   }
-
   role_bindings {
     role = "workspace.edit"
     subjects {
@@ -258,7 +261,7 @@ Required:
 
 Required:
 
-- `kind` (String) Subject type, having one of the subject types: USER, GROUP, or K8S_SERVICEACCOUNT
+- `kind` (String) Subject type, having one of the subject types: USER or GROUP or K8S_SERVICEACCOUNT
 - `name` (String) Subject name: allow max characters for email - 320 characters.
 
 

--- a/examples/resources/iam_policy/resource_iam_workspace_k8s_svcaccnt.tf
+++ b/examples/resources/iam_policy/resource_iam_workspace_k8s_svcaccnt.tf
@@ -1,0 +1,19 @@
+/*
+ Workspace scoped Tanzu Mission Control IAM policy using a K8s Service Account
+ This resource is applied on a workspace to provision the role bindings on the associated workspace.
+ The defined scope block can be updated to change the access policy's scope.
+ */
+resource "tanzu-mission-control_iam_policy" "workspace_scoped_iam_policy" {
+  scope {
+    workspace {
+      name = "tf-workspace"
+    }
+  }
+  role_bindings {
+    role = "workspace.edit"
+    subjects {
+      name = "namespace:serviceaccountname"
+      kind = "K8S_SERVICEACCOUNT"
+    }
+  }
+}

--- a/internal/resources/iampolicy/role_bindings.go
+++ b/internal/resources/iampolicy/role_bindings.go
@@ -43,7 +43,7 @@ var roleBinding = &schema.Schema{
 						},
 						subjectKindKey: {
 							Type:         schema.TypeString,
-							Description:  "Subject type, having one of the subject types: USER or GROUP",
+							Description:  "Subject type, having one of the subject types: USER or GROUP or K8S_SERVICEACCOUNT",
 							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"USER", "GROUP", "K8S_SERVICEACCOUNT"}, false),
 						},

--- a/templates/resources/iam_policy.md.tmpl
+++ b/templates/resources/iam_policy.md.tmpl
@@ -57,6 +57,12 @@ For more information, see [Managing Access to Resources.][managing-access]
 
 {{ tffile "examples/resources/iam_policy/resource_iam_workspace.tf" }}
 
+## Workspace scoped IAM Policy using a K8s Service Account
+
+### Example Usage
+
+{{ tffile "examples/resources/iam_policy/resource_iam_workspace_k8s_svcaccnt.tf" }}
+
 ## Namespace scoped IAM Policy
 
 ### Example Usage


### PR DESCRIPTION
1. **What this PR does / why we need it**:
     New policy kind K8S_SERVICEACCOUNT for I am policy resource is included as part of MR https://github.com/vmware/terraform-provider-tanzu-mission-control/pull/243/files. This change adds the examples and update the doc as per the terraform documentation guidelines

3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->