### PR TITLE
Update the kubernetes version from 1.24.x to 1.25.11 for AKS tests and example tf file

### DIFF
--- a/docs/resources/akscluster.md
+++ b/docs/resources/akscluster.md
@@ -60,7 +60,7 @@ resource "tanzu-mission-control_akscluster" "demo_AKS_cluster" {
   spec {
     config {
       location           = "eastus"
-      kubernetes_version = "1.24.10"
+      kubernetes_version = "1.25.11"
       network_config {
         dns_prefix = "dns-tf-test"
       }

--- a/examples/resources/akscluster/minimal_cluster.tf
+++ b/examples/resources/akscluster/minimal_cluster.tf
@@ -27,7 +27,7 @@ resource "tanzu-mission-control_akscluster" "demo_AKS_cluster" {
   spec {
     config {
       location           = "eastus"
-      kubernetes_version = "1.24.10"
+      kubernetes_version = "1.25.11"
       network_config {
         dns_prefix = "dns-tf-test"
       }

--- a/internal/resources/akscluster/resource_akscluster_acc_test.go
+++ b/internal/resources/akscluster/resource_akscluster_acc_test.go
@@ -390,7 +390,7 @@ func testAKSCluster(fn *aksmodel.VmwareTanzuManageV1alpha1AksclusterFullName) st
   spec {
     config {
       location = "eastus"
-      kubernetes_version = "1.24.10"
+      kubernetes_version = "1.25.11"
       network_config {
         dns_prefix = "dns-tf-test"
       }
@@ -420,7 +420,7 @@ func testAKSClusterEnableCSI(fn *aksmodel.VmwareTanzuManageV1alpha1AksclusterFul
   spec {
     config {
       location = "eastus"
-      kubernetes_version = "1.24.10"
+      kubernetes_version = "1.25.11"
       network_config {
         dns_prefix = "dns-tf-test"
       }
@@ -450,7 +450,7 @@ func testAKSClusterAddUserNodepool(fn *aksmodel.VmwareTanzuManageV1alpha1Aksclus
   spec {
     config {
       location = "eastus"
-      kubernetes_version = "1.24.10"
+      kubernetes_version = "1.25.11"
       network_config {
         dns_prefix = "dns-tf-test"
       }
@@ -501,7 +501,7 @@ func mockCluster(w ...clusterWither) *aksmodel.VmwareTanzuManageV1alpha1AksClust
 					EnableDiskCsiDriver: false,
 					EnableFileCsiDriver: false,
 				},
-				Version: "1.24.10",
+				Version: "1.25.11",
 			},
 		},
 		Status: &aksmodel.VmwareTanzuManageV1alpha1AksclusterStatus{


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Updates AKS tests (and tf example file) from 1.24.x kubernetes to 1.25.11 kubernetes. This is because running these tests against my stack yields test failures as 1.24.x is no longer supported / is no longer a valid kubernetes version.

2. **Which issue(s) this PR fixes**

N/A

3. **Additional information**

Running all the tests locally via `make test` would yield test failures including the following:
```
--- FAIL: TestAccAksCluster_basics (24.86s)
    resource_akscluster_acc_test.go:253: Step 1/4 error: Error running apply: exit status 1

        Error: Cluster creation failed: {"OperationCompleted":{"lastTransitionTime":"2023-08-28T14:05:10.825Z","message":"code = InvalidArgument desc = create/update AKS: AgentPoolK8sVersionNotSupported: Version 1.24.10 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list","reason":"ControlPlaneCreationFailedToInitialize","severity":"ERROR","status":"FALSE","type":"OperationCompleted"},"Ready":{"lastTransitionTime":"2023-08-28T14:05:10.839Z","message":"code = InvalidArgument desc = create/update AKS: AgentPoolK8sVersionNotSupported: Version 1.24.10 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list","reason":"OperationCompletedError","severity":"ERROR","status":"FALSE","type":"Ready"}}

          with tanzu-mission-control_akscluster.tf-acc-test-ws2v1,
          on terraform_plugin_test.tf line 1, in resource "tanzu-mission-control_akscluster" "tf-acc-test-ws2v1":
           1: resource "tanzu-mission-control_akscluster" "tf-acc-test-ws2v1" {

FAIL
```
This would happen as where my stack is deployed no longer supports / offers kubernetes 1.24.x. Updating the version in the AKS tests to 1.25.11 results in the tests working again as kubernetes 1.25.x is still supported.

4. **Special notes for your reviewer**

Signed-off-by: Gavin Shaw <gavins@vmware.com>
Signed-off-by: Gavin Shaw <gshaw+github@pivotal.io>

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->