### PR TITLE
Add wait timeout support to credential resource

### DIFF
--- a/docs/data-sources/credential.md
+++ b/docs/data-sources/credential.md
@@ -25,6 +25,7 @@ data "tanzu-mission-control_credential" "test_cred" {
 ### Optional
 
 - `meta` (Block List, Max: 1) Metadata for the resource (see [below for nested schema](#nestedblock--meta))
+- `ready_wait_timeout` (String) Wait timeout duration until credential resource reaches VALID state. Accepted timeout duration values like 5s, 5m, or 1h, higher than zero.
 - `spec` (Block List, Max: 1) Spec of credential resource (see [below for nested schema](#nestedblock--spec))
 
 ### Read-Only

--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -33,6 +33,7 @@ resource "tanzu-mission-control_credential" "aws_eks_cred" {
       }
     }
   }
+  ready_wait_timeout = "2m" // Wait time for credential create operations to finish (default: 3m).
 }
 ```
 
@@ -182,6 +183,7 @@ resource "tanzu-mission-control_credential" "tanzu_observability_cred" {
 ### Optional
 
 - `meta` (Block List, Max: 1) Metadata for the resource (see [below for nested schema](#nestedblock--meta))
+- `ready_wait_timeout` (String) Wait timeout duration until credential resource reaches VALID state. Accepted timeout duration values like 5s, 5m, or 1h, higher than zero.
 - `spec` (Block List, Max: 1) Spec of credential resource (see [below for nested schema](#nestedblock--spec))
 
 ### Read-Only

--- a/examples/resources/credential/aws_eks.tf
+++ b/examples/resources/credential/aws_eks.tf
@@ -22,4 +22,5 @@ resource "tanzu-mission-control_credential" "aws_eks_cred" {
       }
     }
   }
+  ready_wait_timeout = "2m" // Wait time for credential create operations to finish (default: 3m).
 }

--- a/internal/helper/retry.go
+++ b/internal/helper/retry.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const DoNotRetry = "do_not_retry"
+
 // Retryable is a simple function which can be retried, returns (retry[yes/no], error).
 type Retryable func() (bool, error)
 

--- a/internal/resources/credential/constants.go
+++ b/internal/resources/credential/constants.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: MPL-2.0
 package credential
 
 const (
+	ResourceName = "tanzu-mission-control_credential"
+
 	NameKey              = "name"
 	specKey              = "spec"
 	statusKey            = "status"
@@ -21,5 +23,5 @@ const (
 	iamRoleARNKey    = "arn"
 	iamRoleExtIDKey  = "ext_id"
 	typeKey          = "type"
-	ResourceName     = "tanzu-mission-control_credential"
+	waitKey          = "ready_wait_timeout"
 )

--- a/internal/resources/credential/datasource_credential.go
+++ b/internal/resources/credential/datasource_credential.go
@@ -7,6 +7,9 @@ package credential
 
 import (
 	"context"
+	"log"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -18,6 +21,8 @@ import (
 	credentialsmodels "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/credential"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
+
+const defaultWaitTimeout = 3 * time.Minute
 
 func DataSourceCredential() *schema.Resource {
 	return &schema.Resource{
@@ -39,14 +44,55 @@ func dataSourceCredentialRead(ctx context.Context, d *schema.ResourceData, m int
 
 	name, _ := d.Get(NameKey).(string)
 
-	resp, err = config.TMCConnection.CredentialResourceService.CredentialResourceServiceGet(constructFullname(d))
-	if err != nil || resp == nil {
-		if clienterrors.IsNotFoundError(err) && !helper.IsDataRead(ctx) {
-			_ = schema.RemoveFromState(d, m)
-			return diags
+	getCredentialResourceRetryableFunc := func() (retry bool, err error) {
+		resp, err = config.TMCConnection.CredentialResourceService.CredentialResourceServiceGet(constructFullname(d))
+		if err != nil || resp == nil {
+			if clienterrors.IsNotFoundError(err) && !helper.IsDataRead(ctx) {
+				_ = schema.RemoveFromState(d, m)
+				return false, nil
+			}
+
+			return true, errors.Wrapf(err, "unable to get Tanzu Mission Control credential entry, name : %s", name)
 		}
 
-		return diag.FromErr(errors.Wrapf(err, "unable to get Tanzu Mission Control credential entry, name : %s", name))
+		if resp.Credential.Status == nil || resp.Credential.Status.Phase == nil {
+			return true, errors.Errorf("status or phase not found for Tanzu Mission Control credential entry, name: %s", name)
+		}
+
+		if !strings.EqualFold(string(*resp.Credential.Status.Phase), string(credentialsmodels.VmwareTanzuManageV1alpha1AccountCredentialStatusPhaseVALID)) {
+			log.Printf("[DEBUG] waiting for creadential(%s) to be in VALID phase", name)
+			return true, nil
+		}
+
+		return false, nil
+	}
+
+	timeoutData := d.Get(waitKey).(string)
+	if !helper.IsCreateState(ctx) {
+		timeoutData = helper.DoNotRetry
+	}
+
+	var timeoutDuration time.Duration
+
+	switch timeoutData {
+	case helper.DoNotRetry:
+		_, err = getCredentialResourceRetryableFunc()
+	default:
+		var parseErr error
+		timeoutDuration, parseErr = time.ParseDuration(timeoutData)
+
+		if parseErr != nil {
+			log.Printf("[INFO] unable to parse the duration value for the key %s. Defaulting to %s minutes"+
+				" Please refer to 'https://pkg.go.dev/time#ParseDuration' for providing the right value", waitKey, defaultWaitTimeout)
+
+			timeoutDuration = defaultWaitTimeout
+		}
+
+		_, err = helper.RetryUntilTimeout(getCredentialResourceRetryableFunc, 10*time.Second, timeoutDuration)
+	}
+
+	if err != nil || resp == nil || resp.Credential == nil {
+		return diag.FromErr(errors.Wrapf(err, "Unable to get Tanzu Mission Control credential entry, name : %s", d.Get(NameKey)))
 	}
 
 	d.SetId(resp.Credential.Meta.UID)

--- a/internal/resources/credential/resource_credential.go
+++ b/internal/resources/credential/resource_credential.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
 	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
 	credentialsmodels "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/credential"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
 )
@@ -42,6 +43,12 @@ var credentialSchema = map[string]*schema.Schema{
 		Description: "Status of credential resource",
 		Computed:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
+	},
+	waitKey: {
+		Type:        schema.TypeString,
+		Description: "Wait timeout duration until credential resource reaches VALID state. Accepted timeout duration values like 5s, 5m, or 1h, higher than zero.",
+		Default:     defaultWaitTimeout.String(),
+		Optional:    true,
 	},
 }
 
@@ -106,7 +113,7 @@ func resourceCredentialCreate(ctx context.Context, d *schema.ResourceData, m int
 
 	d.SetId(response.Credential.Meta.UID)
 
-	return dataSourceCredentialRead(ctx, d, m)
+	return dataSourceCredentialRead(helper.GetContextWithCaller(ctx, helper.CreateState), d, m)
 }
 
 func resourceCredentialDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {


### PR DESCRIPTION
1. **What this PR does / why we need it**:
      This PR adds timeout field to credential resource with which use can wait for the specified time until the supported credential reaches VALID state
2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #Issue reported over Jira


3. **Additional information**


4. **Special notes for your reviewer**

- With default timeout of 3m
![Screenshot 2023-08-29 at 5 10 53 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/80737804/9ca3dbc6-108b-400f-8b81-d38bde4bc42a)
