### PR TITLE
Fix the annotation for the image registry addition to TMC using credential resource

### DIFF
--- a/internal/resources/credential/resource_credential_test.go
+++ b/internal/resources/credential/resource_credential_test.go
@@ -67,7 +67,7 @@ meta {
       "key2" : "value2"
     }
     annotations = {
-      "repository-path" : "something"
+      "registry-namespace" : "something"
     }
   }
 


### PR DESCRIPTION

Involves fixing the incorrect annotation from "repository-path" to  "registry-namespace"

1. **What this PR does / why we need it**:

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes # Issue tracked in Jira


3. **Additional information**
Local testrun
<img width="952" alt="Screenshot 2023-09-22 at 5 44 14 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/80737804/e5dcb0ae-f5e1-41b1-93a6-36c972b010af">


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->