### PR TITLE
Feat/dataprotection-enable -- Initial client, models and tf schema

### DIFF
--- a/internal/client/cluster/dataprotection/dataprotection_resource.go
+++ b/internal/client/cluster/dataprotection/dataprotection_resource.go
@@ -1,0 +1,94 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotectionclient
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/transport"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	dataprotectionmodels "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/dataprotection"
+)
+
+const (
+	apiVersionAndGroup = "v1alpha1/clusters"
+	dataProtectionPath = "dataprotection"
+)
+
+// New creates a new cluster resource service API client.
+func New(transport *transport.Client) ClientService {
+	return &Client{Client: transport}
+}
+
+/*
+Client for credentials resource service API.
+*/
+type Client struct {
+	*transport.Client
+}
+
+// ClientService is the interface for Client methods.
+type ClientService interface {
+	DataProtectionResourceServiceCreate(request *dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest) (*dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse, error)
+
+	DataProtectionResourceServiceDelete(fn *dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionFullName, destroyBackups bool) error
+
+	DataProtectionResourceServiceList(clusterName string) (*dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionListDataProtectionsResponse, error)
+
+	DataProtectionResourceServiceUpdate(request *dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest) (*dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse, error)
+}
+
+/*
+DataProtectionResourceServiceCreate enables data protection on a cluster.
+*/
+func (c *Client) DataProtectionResourceServiceCreate(request *dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest,
+) (*dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse, error) {
+	response := &dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse{}
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup, request.DataProtection.FullName.ClusterName, dataProtectionPath).String()
+	err := c.Create(requestURL, request, response)
+
+	return response, err
+}
+
+/*
+DataProtectionResourceServiceDelete disables data protection on a cluster.
+*/
+func (c *Client) DataProtectionResourceServiceDelete(fn *dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionFullName, deleteBackups bool) error {
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup, fn.ClusterName, dataProtectionPath)
+	queryParams := url.Values{}
+
+	queryParams.Add("fullName.provisionerName", fn.ProvisionerName)
+	queryParams.Add("fullName.managementClusterName", fn.ManagementClusterName)
+	queryParams.Add("delete_backups", strconv.FormatBool(deleteBackups))
+
+	requestURL = requestURL.AppendQueryParams(queryParams)
+
+	return c.Delete(requestURL.String())
+}
+
+/*
+DataProtectionResourceServiceList gets data protection details.
+*/
+func (c *Client) DataProtectionResourceServiceList(clusterName string) (*dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionListDataProtectionsResponse, error) {
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup, clusterName, dataProtectionPath).String()
+	resp := &dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionListDataProtectionsResponse{}
+	err := c.Get(requestURL, resp)
+
+	return resp, err
+}
+
+/*
+DataProtectionResourceServiceUpdate updates a data protection configuration on a cluster.
+*/
+func (c *Client) DataProtectionResourceServiceUpdate(request *dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest,
+) (*dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse, error) {
+	response := &dataprotectionmodels.VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse{}
+	requestURL := helper.ConstructRequestURL(apiVersionAndGroup, request.DataProtection.FullName.ClusterName, dataProtectionPath).String()
+	err := c.Update(requestURL, request, response)
+
+	return response, err
+}

--- a/internal/client/http_client.go
+++ b/internal/client/http_client.go
@@ -14,6 +14,7 @@ import (
 	clusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster"
 	backupscheduleclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/backupschedule"
 	continuousdeliveryclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/continuousdelivery"
+	dataprotectionclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/dataprotection"
 	gitrepositoryclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/gitrepository"
 	iamclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/iam_policy"
 	kustomizationclusterclient "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/cluster/kustomization"
@@ -114,6 +115,7 @@ func newHTTPClient(httpClient *transport.Client) *TanzuMissionControl {
 		TanzupackageResourceService:                   packageclusterclient.New(httpClient),
 		PackageInstallResourceService:                 pkginstallclusterclient.New(httpClient),
 		BackupScheduleService:                         backupscheduleclient.New(httpClient),
+		DataProtectionService:                         dataprotectionclient.New(httpClient),
 	}
 }
 
@@ -157,4 +159,5 @@ type TanzuMissionControl struct {
 	TanzupackageResourceService                   packageclusterclient.ClientService
 	PackageInstallResourceService                 pkginstallclusterclient.ClientService
 	BackupScheduleService                         backupscheduleclient.ClientService
+	DataProtectionService                         dataprotectionclient.ClientService
 }

--- a/internal/models/cluster/dataprotection/data_protection.go
+++ b/internal/models/cluster/dataprotection/data_protection.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotectionmodels
+
+import (
+	"github.com/go-openapi/swag"
+
+	objectmetamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/objectmeta"
+)
+
+// VmwareTanzuManageV1alpha1ClusterDataprotectionDataProtection Backup, restore, or migrate cluster data.
+//
+// Protect Kubernetes cluster data with the DataProtection resource. Backup, restore, or.
+// migrate cluster objects and volumes.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.dataprotection.DataProtection.
+type VmwareTanzuManageV1alpha1ClusterDataprotectionDataProtection struct {
+
+	// Full name for the DataProtection.
+	FullName *VmwareTanzuManageV1alpha1ClusterDataprotectionFullName `json:"fullName,omitempty"`
+
+	// Metadata for the DataProtection object.
+	Meta *objectmetamodel.VmwareTanzuCoreV1alpha1ObjectMeta `json:"meta,omitempty"`
+
+	// Spec field for DataProtection.
+	Spec *VmwareTanzuManageV1alpha1ClusterDataprotectionSpec `json:"spec"`
+
+	// Status field.
+	Status *VmwareTanzuManageV1alpha1ClusterDataprotectionStatus `json:"status,omitempty"`
+
+	// Metadata describing the type of the resource.
+	Type *objectmetamodel.VmwareTanzuCoreV1alpha1ObjectType `json:"type,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionDataProtection) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionDataProtection) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ClusterDataprotectionDataProtection
+
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/models/cluster/dataprotection/fullname.go
+++ b/internal/models/cluster/dataprotection/fullname.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotectionmodels
+
+import (
+	"github.com/go-openapi/swag"
+)
+
+// VmwareTanzuManageV1alpha1ClusterDataprotectionFullName Full name of the namespace. This includes the object name along.
+// with any parents or further identifiers.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.dataprotection.FullName.
+type VmwareTanzuManageV1alpha1ClusterDataprotectionFullName struct {
+
+	// Name of Cluster.
+	ClusterName string `json:"clusterName,omitempty"`
+
+	// Name of management cluster.
+	ManagementClusterName string `json:"managementClusterName,omitempty"`
+
+	// ID of Organization.
+	OrgID string `json:"orgId,omitempty"`
+
+	// Name of Provisioner.
+	ProvisionerName string `json:"provisionerName,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionFullName) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionFullName) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ClusterDataprotectionFullName
+
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/models/cluster/dataprotection/requests.go
+++ b/internal/models/cluster/dataprotection/requests.go
@@ -1,0 +1,106 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotectionmodels
+
+import (
+	"github.com/go-openapi/swag"
+)
+
+// VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest Request to create a DataProtection.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.dataprotection.CreateDataProtectionRequest.
+type VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest struct {
+
+	// DataProtection to create.
+	DataProtection *VmwareTanzuManageV1alpha1ClusterDataprotectionDataProtection `json:"dataProtection,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionRequest
+
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}
+
+// VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse Response from creating a DataProtection.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.dataprotection.CreateDataProtectionResponse.
+type VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse struct {
+
+	// DataProtection created.
+	DataProtection *VmwareTanzuManageV1alpha1ClusterDataprotectionDataProtection `json:"dataProtection,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ClusterDataprotectionCreateDataProtectionResponse
+
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}
+
+// VmwareTanzuManageV1alpha1ClusterDataprotectionListDataProtectionsResponse Response from listing DataProtections.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.dataprotection.ListDataProtectionsResponse.
+type VmwareTanzuManageV1alpha1ClusterDataprotectionListDataProtectionsResponse struct {
+
+	// List of dataprotections.
+	DataProtections []*VmwareTanzuManageV1alpha1ClusterDataprotectionDataProtection `json:"dataProtections"`
+
+	// Total count.
+	TotalCount string `json:"totalCount,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionListDataProtectionsResponse) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionListDataProtectionsResponse) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ClusterDataprotectionListDataProtectionsResponse
+
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/models/cluster/dataprotection/spec.go
+++ b/internal/models/cluster/dataprotection/spec.go
@@ -1,0 +1,47 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotectionmodels
+
+import (
+	"github.com/go-openapi/swag"
+)
+
+// VmwareTanzuManageV1alpha1ClusterDataprotectionSpec The spec collects all the options for installing backup and restore solution into a Kubernetes cluster.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.dataprotection.Spec.
+type VmwareTanzuManageV1alpha1ClusterDataprotectionSpec struct {
+	// A flag to indicate whether to skip installation of restic server (https://github.com/restic/restic).
+	// Otherwise, restic would be enabled by default as part of Data Protection installation.
+	DisableRestic bool `json:"disableRestic"`
+
+	// A flag to indicate whether to backup all the supported API Group versions of a resource on the cluster.
+	EnableAllAPIGroupVersionsBackup bool `json:"enableAllApiGroupVersionsBackup"`
+
+	// A flag to indicate whether to install CSI snapshotting related capabilities.
+	EnableCsiSnapshots bool `json:"enableCsiSnapshots"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionSpec) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionSpec) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ClusterDataprotectionSpec
+
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/models/cluster/dataprotection/status.go
+++ b/internal/models/cluster/dataprotection/status.go
@@ -1,0 +1,66 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotectionmodels
+
+import (
+	"github.com/go-openapi/swag"
+
+	statusmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/status"
+)
+
+// VmwareTanzuManageV1alpha1ClusterDataprotectionStatus Status of the DataProtection configure resource.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.dataprotection.Status.
+type VmwareTanzuManageV1alpha1ClusterDataprotectionStatus struct {
+
+	// A list of available phases for data protection object.
+	AvailablePhases []*VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase `json:"availablePhases"`
+
+	// The conditions attached to this data protection object.
+	// The description of the conditions is as follows:
+	// - "Scheduled" with status 'Unknown' indicates the request has not been applied to the cluster yet.
+	// - "Scheduled" with status 'True' and "Ready" with status 'Unknown' indicates the data protection create / delete intent has been applied / deleted but not yet acted upon.
+	// - "Ready" with status 'True' indicates the the creation of data protection is complete.
+	// - "Ready" with status 'False' indicates the the creation of data protection is in error state.
+	Conditions map[string]statusmodel.VmwareTanzuCoreV1alpha1StatusCondition `json:"conditions,omitempty"`
+
+	// The namespace used to install backup solution.
+	Namespace string `json:"namespace,omitempty"`
+
+	// The resource generation the current status applies to.
+	ObservedGeneration string `json:"observedGeneration,omitempty"`
+
+	// The overall phase of the data protection.
+	Phase *VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase `json:"phase,omitempty"`
+
+	// Additional info about the phase.
+	PhaseInfo string `json:"phaseInfo,omitempty"`
+
+	// The version information of backup solution.
+	Version string `json:"version,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionStatus) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ClusterDataprotectionStatus) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ClusterDataprotectionStatus
+
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/models/cluster/dataprotection/status_phase.go
+++ b/internal/models/cluster/dataprotection/status_phase.go
@@ -1,0 +1,75 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotectionmodels
+
+import (
+	"encoding/json"
+)
+
+// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase Available phases for data protection object.
+//
+//   - PHASE_UNSPECIFIED: Phase_unspecified is the default phase.
+//   - PENDING: Pending phase is set when the data protection object is being processed by the service (TMC).
+//   - CREATING: Creating phase is set when data protection is being enabled on the cluster.
+//   - PENDING_DELETE: Pending delete is set when the data protection delete is being processed by the service.
+//   - DELETING: Deleting the set when the data protection delete is in progress on the the cluster.
+//   - READY: Ready phase is set when the data protection is successfully enabled.
+//   - ERROR: Error phase is set when there was a failure while creating/deleting data protection.
+//   - UPDATING: Updating is set when the data protection is being updated.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.cluster.dataprotection.Status.Phase.
+type VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase string
+
+func NewVmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase(value VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase) *VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase {
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase.
+func (m VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase) Pointer() *VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase {
+	return &m
+}
+
+const (
+
+	// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhasePHASEUNSPECIFIED captures enum value "PHASE_UNSPECIFIED".
+	VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhasePHASEUNSPECIFIED VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase = "PHASE_UNSPECIFIED"
+
+	// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhasePENDING captures enum value "PENDING".
+	VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhasePENDING VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase = "PENDING"
+
+	// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseCREATING captures enum value "CREATING".
+	VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseCREATING VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase = "CREATING"
+
+	// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhasePENDINGDELETE captures enum value "PENDING_DELETE".
+	VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhasePENDINGDELETE VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase = "PENDING_DELETE"
+
+	// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseDELETING captures enum value "DELETING".
+	VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseDELETING VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase = "DELETING"
+
+	// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseREADY captures enum value "READY".
+	VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseREADY VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase = "READY"
+
+	// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseERROR captures enum value "ERROR".
+	VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseERROR VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase = "ERROR"
+
+	// VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseUPDATING captures enum value "UPDATING".
+	VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseUPDATING VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase = "UPDATING"
+)
+
+// for schema.
+var vmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseEnum []interface{}
+
+func init() {
+	var res []VmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhase
+
+	if err := json.Unmarshal([]byte(`["PHASE_UNSPECIFIED","PENDING","CREATING","PENDING_DELETE","DELETING","READY","ERROR","UPDATING"]`), &res); err != nil {
+		panic(err)
+	}
+
+	for _, v := range res {
+		vmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseEnum = append(vmwareTanzuManageV1alpha1ClusterDataprotectionStatusPhaseEnum, v)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/akscluster"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/backupschedule"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/dataprotection"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/integration"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/nodepools"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/clustergroup"
@@ -67,6 +68,7 @@ func Provider() *schema.Provider {
 			tanzupackageinstall.ResourceName: tanzupackageinstall.ResourcePackageInstall(),
 			kubernetessecret.ResourceName:    kubernetessecret.ResourceSecret(),
 			backupschedule.ResourceName:      backupschedule.ResourceBackupSchedule(),
+			dataprotection.ResourceName:      dataprotection.ResourceEnableDataProtection(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			cluster.ResourceName:             cluster.DataSourceTMCCluster(),

--- a/internal/resources/cluster/dataprotection/resource_enable_data_protection.go
+++ b/internal/resources/cluster/dataprotection/resource_enable_data_protection.go
@@ -1,0 +1,16 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotection
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ResourceEnableDataProtection() *schema.Resource {
+	return &schema.Resource{
+		Schema: enableDataProtectionSchema,
+	}
+}

--- a/internal/resources/cluster/dataprotection/schema.go
+++ b/internal/resources/cluster/dataprotection/schema.go
@@ -1,0 +1,107 @@
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package dataprotection
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/common"
+)
+
+const (
+	ResourceName = "tanzu-mission-control_enable_data_protection"
+
+	// Root Keys.
+	ClusterNameKey           = "cluster_name"
+	ManagementClusterNameKey = "management_cluster_name"
+	ProvisionerNameKey       = "provisioner_name"
+	SpecKey                  = "spec"
+	DeletionPolicyKey        = "deletion_policy"
+
+	// Spec Directive Keys.
+	EnableCSISnapshotsKey              = "enable_csi_snapshots"
+	DisableResticKey                   = "disable_restic"
+	EnableAllAPIGroupVersionsBackupKey = "enable_all_api_group_versions_backup"
+
+	// Deletion Policy Directive Keys.
+	DeleteBackupsKey = "delete_backups"
+)
+
+var enableDataProtectionSchema = map[string]*schema.Schema{
+	ClusterNameKey:           clusterNameSchema,
+	ManagementClusterNameKey: managementClusterNameSchema,
+	ProvisionerNameKey:       provisionerNameSchema,
+	SpecKey:                  specSchema,
+	common.MetaKey:           common.Meta,
+	DeletionPolicyKey:        deletionPolicySchema,
+}
+
+var clusterNameSchema = &schema.Schema{
+	Type:        schema.TypeString,
+	Description: "Cluster name",
+	Required:    true,
+	ForceNew:    true,
+}
+
+var managementClusterNameSchema = &schema.Schema{
+	Type:        schema.TypeString,
+	Description: "Management cluster name",
+	Required:    true,
+	ForceNew:    true,
+}
+
+var provisionerNameSchema = &schema.Schema{
+	Type:        schema.TypeString,
+	Description: "Cluster provisioner name",
+	Required:    true,
+	ForceNew:    true,
+}
+
+var specSchema = &schema.Schema{
+	Type:        schema.TypeList,
+	Description: "Spec of enable data protection",
+	Optional:    true,
+	MaxItems:    1,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			EnableCSISnapshotsKey: {
+				Type:        schema.TypeBool,
+				Description: "A flag to indicate whether to install CSI snapshotting related capabilities.\n(Default: False)",
+				Default:     false,
+				Optional:    true,
+			},
+			DisableResticKey: {
+				Type:        schema.TypeBool,
+				Description: "A flag to indicate whether to skip installation of restic server (https://github.com/restic/restic).\nOtherwise, restic would be enabled by default as part of Data Protection installation.\n(Default: False)",
+				Default:     false,
+				Optional:    true,
+			},
+			EnableAllAPIGroupVersionsBackupKey: {
+				Type:        schema.TypeBool,
+				Description: "A flag to indicate whether to backup all the supported API Group versions of a resource on the cluster.\n(Default: False)",
+				Default:     false,
+				Optional:    true,
+			},
+		},
+	},
+}
+
+var deletionPolicySchema = &schema.Schema{
+	Type:        schema.TypeList,
+	Description: "Deletion policy block of data protection",
+	Optional:    true,
+	MaxItems:    1,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			DeleteBackupsKey: {
+				Type:        schema.TypeBool,
+				Description: "Destroy backups upon deleting data protection.\n(default: false)",
+				Default:     false,
+				Optional:    true,
+			},
+		},
+	},
+}


### PR DESCRIPTION
1. **What this PR does / why we need it**:
       This PR includes the Swagger API Models & Clients along with the Terraform Schema Design for enabling data protection 
       on a cluster.

2. **Which issue(s) this PR fixes**
        -

3. **Additional information**
       -

4. **Special notes for your reviewer**
       -