### PR TITLE
Add fix for source secret resource

### DIFF
--- a/internal/resources/sourcesecret/resource_sourcesecret.go
+++ b/internal/resources/sourcesecret/resource_sourcesecret.go
@@ -367,6 +367,18 @@ func updateCheckForMeta(d *schema.ResourceData, meta *objectmetamodel.VmwareTanz
 
 func updateCheckForSpec(d *schema.ResourceData, atomicSpec *sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretSpec, scope commonscope.Scope) bool {
 	if !spec.HasSpecChanged(d) {
+		if *atomicSpec.SourceSecretType == *sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeUSERNAMEPASSWORD) {
+			specTypeData, _ := (d.Get(helper.GetFirstElementOf(spec.SpecKey, spec.DataKey, spec.UsernamePasswordKey, spec.PasswordKey))).(string)
+			val, _ := spec.GetEncodedSpecData(specTypeData)
+			atomicSpec.Data.Data[spec.PasswordKey] = val
+		}
+
+		if *atomicSpec.SourceSecretType == *sourcesecretclustermodel.NewVmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretType(sourcesecretclustermodel.VmwareTanzuManageV1alpha1ClusterFluxcdSourcesecretTypeSSH) {
+			specTypeData, _ := (d.Get(helper.GetFirstElementOf(spec.SpecKey, spec.DataKey, spec.SSHKey, spec.IdentityKey))).(string)
+			val, _ := spec.GetEncodedSpecData(specTypeData)
+			atomicSpec.Data.Data[spec.IdentityKey] = val
+		}
+
 		return false
 	}
 

--- a/internal/resources/sourcesecret/spec/cluster_scope.go
+++ b/internal/resources/sourcesecret/spec/cluster_scope.go
@@ -59,8 +59,8 @@ func ConstructSpecForClusterScope(d *schema.ResourceData) (spec *sourcesecretclu
 						sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpecSecretTypeOPAQUESECRETTYPE,
 					)
 
-					unamekeyData, _ := getEncodedSpecData(username)
-					passwordkeyData, _ := getEncodedSpecData(password)
+					unamekeyData, _ := GetEncodedSpecData(username)
+					passwordkeyData, _ := GetEncodedSpecData(password)
 					specData := map[string]strfmt.Base64{
 						usernameKey: unamekeyData,
 						PasswordKey: passwordkeyData,
@@ -96,8 +96,8 @@ func ConstructSpecForClusterScope(d *schema.ResourceData) (spec *sourcesecretclu
 						sourcesecretclustermodel.VmwareTanzuManageV1alpha1AccountCredentialTypeKeyvalueSpecSecretTypeOPAQUESECRETTYPE,
 					)
 
-					identitydata, _ := getEncodedSpecData(identity)
-					knownhostsdata, _ := getEncodedSpecData(knownhosts)
+					identitydata, _ := GetEncodedSpecData(identity)
+					knownhostsdata, _ := GetEncodedSpecData(knownhosts)
 					specData := map[string]strfmt.Base64{
 						IdentityKey:   identitydata,
 						KnownhostsKey: knownhostsdata,
@@ -166,7 +166,7 @@ func FlattenSpecForClusterScope(spec *sourcesecretclustermodel.VmwareTanzuManage
 	return []interface{}{flattenSpecData}
 }
 
-func getEncodedSpecData(data string) (strfmt.Base64, error) {
+func GetEncodedSpecData(data string) (strfmt.Base64, error) {
 	var secretspecdata strfmt.Base64
 
 	err := secretspecdata.Scan(base64.StdEncoding.EncodeToString([]byte(data)))


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Add fix for source secret resource

Problem :- Since for source secret Type(SSH / usernamePassword) server would return empty value for password / Identity so in a scenario where from TF spec does not change but some thing else changes let say Meta, then in PUT call we are forwarding the value of spec whatever we are getting from server directly which contain empty value for Password / Identity. which will cause issue from server side since empty value for Password / Identity is not allowed.