### PR TITLE
Making Raw and Release notes data more intuitive for package and packages data source

### DIFF
--- a/docs/data-sources/package.md
+++ b/docs/data-sources/package.md
@@ -95,10 +95,20 @@ Read-Only:
 
 - `capacity_requirements_description` (String)
 - `licenses` (Set of String)
-- `release_notes` (String)
+- `release_notes` (List of Object) (see [below for nested schema](#nestedobjatt--spec--release_notes))
 - `released_at` (String)
 - `repository_name` (String)
 - `values_schema` (List of Object) (see [below for nested schema](#nestedobjatt--spec--values_schema))
+
+<a id="nestedobjatt--spec--release_notes"></a>
+### Nested Schema for `spec.release_notes`
+
+Read-Only:
+
+- `metadata_name` (String)
+- `url` (String)
+- `version` (String)
+
 
 <a id="nestedobjatt--spec--values_schema"></a>
 ### Nested Schema for `spec.values_schema`
@@ -112,4 +122,37 @@ Read-Only:
 
 Read-Only:
 
-- `raw` (String)
+- `raw` (List of Object) (see [below for nested schema](#nestedobjatt--spec--values_schema--template--raw))
+
+<a id="nestedobjatt--spec--values_schema--template--raw"></a>
+### Nested Schema for `spec.values_schema.template.raw`
+
+Read-Only:
+
+- `examples` (List of Object) (see [below for nested schema](#nestedobjatt--spec--values_schema--template--raw--examples))
+- `properties` (List of Object) (see [below for nested schema](#nestedobjatt--spec--values_schema--template--raw--properties))
+- `title` (String) Title of object.
+
+<a id="nestedobjatt--spec--values_schema--template--raw--examples"></a>
+### Nested Schema for `spec.values_schema.template.raw.examples`
+
+Read-Only:
+
+- `namespace` (String) Namespace name.
+
+
+<a id="nestedobjatt--spec--values_schema--template--raw--properties"></a>
+### Nested Schema for `spec.values_schema.template.raw.properties`
+
+Read-Only:
+
+- `namespace` (List of Object) (see [below for nested schema](#nestedobjatt--spec--values_schema--template--raw--properties--namespace))
+
+<a id="nestedobjatt--spec--values_schema--template--raw--properties--namespace"></a>
+### Nested Schema for `spec.values_schema.template.raw.properties.namespace`
+
+Read-Only:
+
+- `default` (String) Default value of object.
+- `description` (String) Description of the object of object.
+- `type` (String) Type of object.

--- a/docs/data-sources/packages.md
+++ b/docs/data-sources/packages.md
@@ -84,10 +84,20 @@ Read-Only:
 
 - `capacity_requirements_description` (String)
 - `licenses` (Set of String)
-- `release_notes` (String)
+- `release_notes` (List of Object) (see [below for nested schema](#nestedobjatt--packages--spec--release_notes))
 - `released_at` (String)
 - `repository_name` (String)
 - `values_schema` (List of Object) (see [below for nested schema](#nestedobjatt--packages--spec--values_schema))
+
+<a id="nestedobjatt--packages--spec--release_notes"></a>
+### Nested Schema for `packages.spec.release_notes`
+
+Read-Only:
+
+- `metadata_name` (String)
+- `url` (String)
+- `version` (String)
+
 
 <a id="nestedobjatt--packages--spec--values_schema"></a>
 ### Nested Schema for `packages.spec.values_schema`
@@ -101,4 +111,37 @@ Read-Only:
 
 Read-Only:
 
-- `raw` (String)
+- `raw` (List of Object) (see [below for nested schema](#nestedobjatt--packages--spec--values_schema--template--raw))
+
+<a id="nestedobjatt--packages--spec--values_schema--template--raw"></a>
+### Nested Schema for `packages.spec.values_schema.template.raw`
+
+Read-Only:
+
+- `examples` (List of Object) (see [below for nested schema](#nestedobjatt--packages--spec--values_schema--template--raw--examples))
+- `properties` (List of Object) (see [below for nested schema](#nestedobjatt--packages--spec--values_schema--template--raw--properties))
+- `title` (String) Title of object.
+
+<a id="nestedobjatt--packages--spec--values_schema--template--raw--examples"></a>
+### Nested Schema for `packages.spec.values_schema.template.raw.title`
+
+Read-Only:
+
+- `namespace` (String) Namespace name.
+
+
+<a id="nestedobjatt--packages--spec--values_schema--template--raw--properties"></a>
+### Nested Schema for `packages.spec.values_schema.template.raw.title`
+
+Read-Only:
+
+- `namespace` (List of Object) (see [below for nested schema](#nestedobjatt--packages--spec--values_schema--template--raw--title--namespace))
+
+<a id="nestedobjatt--packages--spec--values_schema--template--raw--title--namespace"></a>
+### Nested Schema for `packages.spec.values_schema.template.raw.title.namespace`
+
+Read-Only:
+
+- `default` (String) Default value of object.
+- `description` (String) Description of the object of object.
+- `type` (String) Type of object.

--- a/internal/resources/package/spec/constant.go
+++ b/internal/resources/package/spec/constant.go
@@ -15,4 +15,36 @@ const (
 	TemplateKey                        = "template"
 	RepositoryNameKey                  = "repository_name"
 	RawKey                             = "raw"
+	metadataNameKey                    = "metadata_name"
+	versionKey                         = "version"
+	urlKey                             = "url"
+	namespaceKey                       = "namespace"
+	examplesKey                        = "examples"
+	propertiesKey                      = "properties"
+	defaultKey                         = "default"
+	descriptionKey                     = "description"
+	typeKey                            = "type"
+	titleKey                           = "title"
+
+	seperatorStr = " "
 )
+
+type RawData struct {
+	Examples   []ExampleData `json:"examples"`
+	Properties NamespaceData `json:"properties"`
+	Title      string        `json:"title"`
+}
+
+type ExampleData struct {
+	Namespace string `json:"namespace"`
+}
+
+type NamespaceData struct {
+	Namespace Data `json:"namespace"`
+}
+
+type Data struct {
+	Default     string `json:"default"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+}

--- a/internal/resources/package/spec/spec.go
+++ b/internal/resources/package/spec/spec.go
@@ -32,11 +32,7 @@ var (
 					Computed:    true,
 					Description: "Minimum capacity requirements to install Package on a cluster.",
 				},
-				ReleaseNotesKey: {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Release notes of Package.",
-				},
+				ReleaseNotesKey: releaseNotesSchema,
 				RepositoryNameKey: {
 					Type:        schema.TypeString,
 					Computed:    true,
@@ -64,10 +60,90 @@ var (
 		Computed:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				RawKey: {
+				RawKey: rawSchema,
+			},
+		},
+	}
+
+	releaseNotesSchema = &schema.Schema{
+		Type:        schema.TypeList,
+		Description: "Release notes of Package.",
+		Computed:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				metadataNameKey: {
 					Type:        schema.TypeString,
 					Computed:    true,
-					Description: "Raw is the underlying serialization of object.",
+					Description: "metadata name.",
+				},
+				versionKey: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "version selection.",
+				},
+				urlKey: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "url for the package",
+				},
+			},
+		},
+	}
+
+	rawSchema = &schema.Schema{
+		Type:        schema.TypeList,
+		Description: "Raw is the underlying serialization of object.",
+		Computed:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				examplesKey: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							namespaceKey: {
+								Type:        schema.TypeString,
+								Description: "Namespace name.",
+								Computed:    true,
+							},
+						},
+					},
+				},
+				propertiesKey: {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							namespaceKey: {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										defaultKey: {
+											Type:        schema.TypeString,
+											Description: "Default value of object.",
+											Computed:    true,
+										},
+										descriptionKey: {
+											Type:        schema.TypeString,
+											Description: "Description of the object of object.",
+											Computed:    true,
+										},
+										typeKey: {
+											Type:        schema.TypeString,
+											Description: "Type of object.",
+											Computed:    true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				titleKey: {
+					Type:        schema.TypeString,
+					Description: "Title of object.",
+					Computed:    true,
 				},
 			},
 		},

--- a/internal/resources/package/spec/spec_flatten_test.go
+++ b/internal/resources/package/spec/spec_flatten_test.go
@@ -34,12 +34,12 @@ func TestFlattenSpecForClusterScope(t *testing.T) {
 				Licenses: []string{
 					"some1",
 				},
-				ReleaseNotes:   "someReleaseNotes",
+				ReleaseNotes:   "cert-manager 1.1.0 https://github.com/jetstack/cert-manager/1.1.0",
 				ReleasedAt:     strfmt.DateTime{},
 				RepositoryName: "testRepo",
 				ValuesSchema: &packageclustermodel.VmwareTanzuManageV1alpha1ClusterNamespaceTanzupackageMetadataPackageValuesSchema{
 					Template: &packageclustermodel.K8sIoApimachineryPkgRuntimeRawExtension{
-						Raw: []byte("somevalue"),
+						Raw: []byte("{\"examples\":[{\"namespace\":\"cert-manager\"}],\"properties\":{\"namespace\":{\"default\":\"cert-manager\",\"description\":\"The namespace in which to deploy cert-manager.\",\"type\":\"string\"}},\"title\":\"cert-manager.tanzu.vmware.com.1.1.0+vmware.1-tkg.2 values schema\"}"),
 					},
 				},
 			},
@@ -50,13 +50,39 @@ func TestFlattenSpecForClusterScope(t *testing.T) {
 						"some1",
 					},
 					RepositoryNameKey: "testRepo",
-					ReleaseNotesKey:   "someReleaseNotes",
-					ReleasedAtKey:     strfmt.DateTime{}.String(),
+					ReleaseNotesKey: []interface{}{
+						map[string]interface{}{
+							metadataNameKey: "cert-manager",
+							versionKey:      "1.1.0",
+							urlKey:          "https://github.com/jetstack/cert-manager/1.1.0",
+						},
+					},
+					ReleasedAtKey: strfmt.DateTime{}.String(),
 					ValuesSchemaKey: []interface{}{
 						map[string]interface{}{
 							TemplateKey: []interface{}{
 								map[string]interface{}{
-									RawKey: "somevalue",
+									RawKey: []interface{}{
+										map[string]interface{}{
+											examplesKey: []interface{}{
+												map[string]interface{}{
+													namespaceKey: "cert-manager",
+												},
+											},
+											propertiesKey: []interface{}{
+												map[string]interface{}{
+													namespaceKey: []interface{}{
+														map[string]interface{}{
+															defaultKey:     "cert-manager",
+															descriptionKey: "The namespace in which to deploy cert-manager.",
+															typeKey:        "string",
+														},
+													},
+												},
+											},
+											titleKey: "cert-manager.tanzu.vmware.com.1.1.0+vmware.1-tkg.2 values schema",
+										},
+									},
 								},
 							},
 						},

--- a/internal/resources/package/test_helper.go
+++ b/internal/resources/package/test_helper.go
@@ -20,8 +20,8 @@ import (
 const (
 	PkgResource         = ResourceName
 	pkgDataSourceVar    = "test_data_source_pkg"
-	pkgName             = "2.0.0"
-	pkgMetadataName     = "pkg.test.carvel.dev"
+	pkgName             = "1.1.0+vmware.1-tkg.2"
+	pkgMetadataName     = "cert-manager.tanzu.vmware.com"
 	globalRepoNamespace = "tanzu-package-repo-global"
 
 	imageURL = "projects.registry.vmware.com/tmc/build-integrations/package/repository/e2e-test-unauth-repo@sha256:87a5f7e0c44523fbc35a9432c657bebce246138bbd0f16d57f5615933ceef632"

--- a/internal/resources/packages/packageslist/constants.go
+++ b/internal/resources/packages/packageslist/constants.go
@@ -6,7 +6,17 @@ SPDX-License-Identifier: MPL-2.0
 package listpackages
 
 const (
-	SpecKey     = "spec"
-	nameKey     = "name"
-	PackagesKey = "packages"
+	SpecKey         = "spec"
+	nameKey         = "name"
+	PackagesKey     = "packages"
+	metadataNameKey = "metadata_name"
+	versionKey      = "version"
+	urlKey          = "url"
+	namespaceKey    = "namespace"
+	examplesKey     = "examples"
+	propertiesKey   = "properties"
+	defaultKey      = "default"
+	descriptionKey  = "description"
+	typeKey         = "type"
+	titleKey        = "title"
 )

--- a/internal/resources/packages/packageslist/flatten_test.go
+++ b/internal/resources/packages/packageslist/flatten_test.go
@@ -42,11 +42,11 @@ func TestFlattenSpecForClusterScope(t *testing.T) {
 								"some1",
 							},
 							RepositoryName: "testrepo1",
-							ReleaseNotes:   "someReleaseNotes",
+							ReleaseNotes:   "cert-manager 1.1.0 https://github.com/jetstack/cert-manager/1.1.0",
 							ReleasedAt:     strfmt.DateTime{},
 							ValuesSchema: &packageclustermodel.VmwareTanzuManageV1alpha1ClusterNamespaceTanzupackageMetadataPackageValuesSchema{
 								Template: &packageclustermodel.K8sIoApimachineryPkgRuntimeRawExtension{
-									Raw: []byte("somevalue"),
+									Raw: []byte("{\"examples\":[{\"namespace\":\"cert-manager\"}],\"properties\":{\"namespace\":{\"default\":\"cert-manager\",\"description\":\"The namespace in which to deploy cert-manager.\",\"type\":\"string\"}},\"title\":\"cert-manager.tanzu.vmware.com.1.1.0+vmware.1-tkg.2 values schema\"}"),
 								},
 							},
 						},
@@ -60,12 +60,12 @@ func TestFlattenSpecForClusterScope(t *testing.T) {
 							Licenses: []string{
 								"some3",
 							},
-							ReleaseNotes:   "someReleaseNotes",
+							ReleaseNotes:   "cert-manager 1.1.0 https://github.com/jetstack/cert-manager/1.1.0",
 							RepositoryName: "testrepo2",
 							ReleasedAt:     strfmt.DateTime{},
 							ValuesSchema: &packageclustermodel.VmwareTanzuManageV1alpha1ClusterNamespaceTanzupackageMetadataPackageValuesSchema{
 								Template: &packageclustermodel.K8sIoApimachineryPkgRuntimeRawExtension{
-									Raw: []byte("somevalue"),
+									Raw: []byte("{\"examples\":[{\"namespace\":\"cert-manager\"}],\"properties\":{\"namespace\":{\"default\":\"cert-manager\",\"description\":\"The namespace in which to deploy cert-manager.\",\"type\":\"string\"}},\"title\":\"cert-manager.tanzu.vmware.com.1.1.0+vmware.1-tkg.2 values schema\"}"),
 								},
 							},
 						},
@@ -82,13 +82,39 @@ func TestFlattenSpecForClusterScope(t *testing.T) {
 								"some1",
 							},
 							packagespec.RepositoryNameKey: "testrepo1",
-							packagespec.ReleaseNotesKey:   "someReleaseNotes",
-							packagespec.ReleasedAtKey:     strfmt.DateTime{}.String(),
+							packagespec.ReleaseNotesKey: []interface{}{
+								map[string]interface{}{
+									metadataNameKey: "cert-manager",
+									versionKey:      "1.1.0",
+									urlKey:          "https://github.com/jetstack/cert-manager/1.1.0",
+								},
+							},
+							packagespec.ReleasedAtKey: strfmt.DateTime{}.String(),
 							packagespec.ValuesSchemaKey: []interface{}{
 								map[string]interface{}{
 									packagespec.TemplateKey: []interface{}{
 										map[string]interface{}{
-											packagespec.RawKey: "somevalue",
+											packagespec.RawKey: []interface{}{
+												map[string]interface{}{
+													examplesKey: []interface{}{
+														map[string]interface{}{
+															namespaceKey: "cert-manager",
+														},
+													},
+													propertiesKey: []interface{}{
+														map[string]interface{}{
+															namespaceKey: []interface{}{
+																map[string]interface{}{
+																	defaultKey:     "cert-manager",
+																	descriptionKey: "The namespace in which to deploy cert-manager.",
+																	typeKey:        "string",
+																},
+															},
+														},
+													},
+													titleKey: "cert-manager.tanzu.vmware.com.1.1.0+vmware.1-tkg.2 values schema",
+												},
+											},
 										},
 									},
 								},
@@ -105,13 +131,39 @@ func TestFlattenSpecForClusterScope(t *testing.T) {
 								"some3",
 							},
 							packagespec.RepositoryNameKey: "testrepo2",
-							packagespec.ReleaseNotesKey:   "someReleaseNotes",
-							packagespec.ReleasedAtKey:     strfmt.DateTime{}.String(),
+							packagespec.ReleaseNotesKey: []interface{}{
+								map[string]interface{}{
+									metadataNameKey: "cert-manager",
+									versionKey:      "1.1.0",
+									urlKey:          "https://github.com/jetstack/cert-manager/1.1.0",
+								},
+							},
+							packagespec.ReleasedAtKey: strfmt.DateTime{}.String(),
 							packagespec.ValuesSchemaKey: []interface{}{
 								map[string]interface{}{
 									packagespec.TemplateKey: []interface{}{
 										map[string]interface{}{
-											packagespec.RawKey: "somevalue",
+											packagespec.RawKey: []interface{}{
+												map[string]interface{}{
+													examplesKey: []interface{}{
+														map[string]interface{}{
+															namespaceKey: "cert-manager",
+														},
+													},
+													propertiesKey: []interface{}{
+														map[string]interface{}{
+															namespaceKey: []interface{}{
+																map[string]interface{}{
+																	defaultKey:     "cert-manager",
+																	descriptionKey: "The namespace in which to deploy cert-manager.",
+																	typeKey:        "string",
+																},
+															},
+														},
+													},
+													titleKey: "cert-manager.tanzu.vmware.com.1.1.0+vmware.1-tkg.2 values schema",
+												},
+											},
 										},
 									},
 								},

--- a/internal/resources/packages/test_helper.go
+++ b/internal/resources/packages/test_helper.go
@@ -20,7 +20,7 @@ import (
 const (
 	PkgsResource        = ResourceName
 	pkgsDataSourceVar   = "test_data_source_pkgs"
-	pkgsMetadataName    = "pkg.test.carvel.dev"
+	pkgsMetadataName    = "cert-manager.tanzu.vmware.com"
 	globalRepoNamespace = "tanzu-package-repo-global"
 
 	imageURL = "projects.registry.vmware.com/tmc/build-integrations/package/repository/e2e-test-unauth-repo@sha256:87a5f7e0c44523fbc35a9432c657bebce246138bbd0f16d57f5615933ceef632"


### PR DESCRIPTION
1. **What this PR does / why we need it**:

 Making Raw and Release notes data more intuitive for package and packages data source
 
 Result :- 
 
 
<img width="1184" alt="Screenshot 2023-10-17 at 2 44 32 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/57012922/ced97abc-07d4-40ad-a63c-b5e87c808448">

--------------------------------------------------

Acceptance tests

<img width="843" alt="Screenshot 2023-10-18 at 11 20 37 AM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/57012922/98746e0a-8518-444c-8a0e-80a358d19c00">

----------------------------------------------------

<img width="856" alt="Screenshot 2023-10-18 at 11 20 43 AM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/57012922/4882ab55-f1ca-4d4a-a936-dfc20d593168">
