### PR TITLE
Set default wait to 30 minutes for eks cluster create

### DIFF
--- a/internal/resources/ekscluster/data_source.go
+++ b/internal/resources/ekscluster/data_source.go
@@ -8,6 +8,7 @@ package ekscluster
 import (
 	"context"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -93,17 +94,16 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 	case "":
 		fallthrough
 	case "default":
-		timeoutValueData = "5m"
+		timeoutValueData = strconv.Itoa(minutesBasedDefaultTimeout) + "m"
 
 		fallthrough
 	default:
 		timeoutDuration, parseErr := time.ParseDuration(timeoutValueData)
 		if parseErr != nil {
-			defaultTimeoutInMinutes := defaultTimeout / time.Minute
 			log.Printf("[INFO] unable to parse the duration value for the key %s. Defaulting to %d minutes(%dm)"+
-				" Please refer to 'https://pkg.go.dev/time#ParseDuration' for providing the right value", waitKey, defaultTimeoutInMinutes, defaultTimeoutInMinutes)
+				" Please refer to 'https://pkg.go.dev/time#ParseDuration' for providing the right value", waitKey, minutesBasedDefaultTimeout, minutesBasedDefaultTimeout)
 
-			timeoutDuration = defaultTimeout
+			timeoutDuration = nanoSecondsBasedDefaultTimeout
 		}
 
 		_, err = helper.RetryUntilTimeout(getEksClusterResourceRetryableFn, 10*time.Second, timeoutDuration)

--- a/internal/resources/ekscluster/resource_ekscluster.go
+++ b/internal/resources/ekscluster/resource_ekscluster.go
@@ -31,7 +31,8 @@ type (
 
 var ignoredTagsPrefix = "tmc.cloud.vmware.com/"
 
-const defaultTimeout = 30 * time.Minute
+const minutesBasedDefaultTimeout = 30
+const nanoSecondsBasedDefaultTimeout = minutesBasedDefaultTimeout * time.Minute
 
 func ResourceTMCEKSCluster() *schema.Resource {
 	return &schema.Resource{
@@ -681,7 +682,7 @@ func getRetryTimeout(d *schema.ResourceData) time.Duration {
 		}
 	}
 
-	return defaultTimeout
+	return nanoSecondsBasedDefaultTimeout
 }
 
 func flattenClusterSpec(item *eksmodel.VmwareTanzuManageV1alpha1EksclusterSpec, nodepools []*eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolDefinition) []interface{} {


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Standardizes the ready wait timeout for EKS cluster creation to 30 minutes.

Introduces 2 constants:
- a constant to hold the timeout in minutes (30)
- a constant to hold the timeout in nano seconds (the base time unit) and derives its value from the first constant
To change the default timeout one only needs to change the value in the 'minutesBasedDefaultTimeout' constant.

Fixes logic in 'internal/resources/ekscluster/data_source.go' where if a user did not provide a 'ready_wait_timeout' key, or provided the value of 'default' it now sets the timeout to 30 minutes instead of 5 minutes.

2. **Which issue(s) this PR fixes**

Revisits Issue #181 

3. **Additional information**


4. **Special notes for your reviewer**
