### PR TITLE
add ability to update default node pool for tkg

### DIFF
--- a/internal/resources/cluster/constants.go
+++ b/internal/resources/cluster/constants.go
@@ -27,4 +27,10 @@ const (
 	distributionKey                = "distribution"
 	versionKey                     = "version"
 	imageRegistryNameKey           = "image_registry"
+	topologyKey                    = "topology"
+	nodePoolKey                    = "node_pools"
+	clusterNameKey                 = "cluster_name"
+	workerNodeCountKey             = "worker_node_count"
+	classKey                       = "class"
+	storageClassKey                = "storage_class"
 )

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -589,7 +589,6 @@ func withMetaUpdate(d *schema.ResourceData, cluster *clustermodel.VmwareTanzuMan
 }
 
 func withTKGNodePoolUpdate(d *schema.ResourceData, nodepool *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolNodepool) bool {
-
 	switch {
 	case nodepool.Spec.TkgServiceVsphere != nil:
 		nodepools := d.Get(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)).([]interface{})[0].(map[string]interface{})
@@ -615,6 +614,7 @@ func withTKGNodePoolUpdate(d *schema.ResourceData, nodepool *nodepoolmodel.Vmwar
 			if incomingTkgServiceVsphereStorageClass != "" {
 				nodepool.Spec.TkgServiceVsphere.StorageClass = incomingTkgServiceVsphereStorageClass
 			}
+
 			log.Printf("[INFO] updating TKGs workload cluster nodepools")
 			return true
 		}
@@ -664,7 +664,7 @@ func resourceClusterInPlaceUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		log.Printf("[INFO] cluster update successful")
 	}
-	//check default nodepool configuration update
+	// check default nodepool configuration update
 	npFullName := constructNpFullName(d)
 	npResp, err := config.TMCConnection.NodePoolResourceService.ManageV1alpha1ClusterNodePoolResourceServiceGet(npFullName)
 	if err != nil {

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -595,6 +595,7 @@ func withTKGNodePoolUpdate(d *schema.ResourceData, nodepool *nodepoolmodel.Vmwar
 		poolSpec := nodepools[SpecKey].([]interface{})[0].(map[string]interface{})
 		// poolInfo := nodepools["info"].([]interface{})[0].(map[string]interface{})
 		tkgsSpec := poolSpec[tkgServiceVsphereKey].([]interface{})[0].(map[string]interface{})
+
 		if d.HasChange(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)) {
 
 			incomingWorkerNodeCount := poolSpec[workerNodeCountKey].(string)
@@ -616,17 +617,21 @@ func withTKGNodePoolUpdate(d *schema.ResourceData, nodepool *nodepoolmodel.Vmwar
 			}
 
 			log.Printf("[INFO] updating TKGs workload cluster nodepools")
+
 			return true
 		}
 	case nodepool.Spec.TkgVsphere != nil:
 		nodepools := d.Get(helper.GetFirstElementOf(SpecKey, tkgVsphereClusterKey, topologyKey, nodePoolKey)).([]interface{})[0].(map[string]interface{})
 		poolSpec := nodepools[SpecKey].([]interface{})[0].(map[string]interface{})
+
 		if d.HasChange(helper.GetFirstElementOf(SpecKey, tkgVsphereClusterKey, topologyKey, nodePoolKey)) {
 			incomingWorkerNodeCount := poolSpec[workerNodeCountKey].(string)
 
 			if incomingWorkerNodeCount != "" {
 				nodepool.Spec.WorkerNodeCount = incomingWorkerNodeCount
 			}
+
+			return true
 		}
 	}
 
@@ -666,6 +671,7 @@ func resourceClusterInPlaceUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 	// check default nodepool configuration update
 	npFullName := constructNpFullName(d)
+
 	npResp, err := config.TMCConnection.NodePoolResourceService.ManageV1alpha1ClusterNodePoolResourceServiceGet(npFullName)
 	if err != nil {
 		return diag.FromErr(errors.Wrapf(err, "Unable to get Tanzu Mission Control cluster node pool entry, name : %s", npFullName.Name))

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -117,8 +117,13 @@ func constructNpFullName(d *schema.ResourceData) (fullname *nodepoolmodel.Vmware
 		fullname.ClusterName = value.(string)
 	}
 
-	if value, ok := d.Get(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)).([]interface{})[0].(map[string]interface{}); ok {
-		poolInfo := value["info"].([]interface{})[0].(map[string]interface{})
+	if value, ok := d.GetOk(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)); ok {
+		np := value.([]interface{})[0].(map[string]interface{})
+		poolInfo := np["info"].([]interface{})[0].(map[string]interface{})
+		fullname.Name = poolInfo["name"].(string)
+	} else if value, ok := d.GetOk(helper.GetFirstElementOf(SpecKey, tkgVsphereClusterKey, topologyKey, nodePoolKey)); ok {
+		np := value.([]interface{})[0].(map[string]interface{})
+		poolInfo := np["info"].([]interface{})[0].(map[string]interface{})
 		fullname.Name = poolInfo["name"].(string)
 	}
 
@@ -629,6 +634,8 @@ func withTKGNodePoolUpdate(d *schema.ResourceData, nodepool *nodepoolmodel.Vmwar
 			if incomingWorkerNodeCount != "" {
 				nodepool.Spec.WorkerNodeCount = incomingWorkerNodeCount
 			}
+
+			log.Printf("[INFO] updating TKGm workload cluster nodepools")
 
 			return true
 		}

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -598,7 +598,6 @@ func withTKGNodePoolUpdate(d *schema.ResourceData, nodepool *nodepoolmodel.Vmwar
 	case nodepool.Spec.TkgServiceVsphere != nil:
 		nodepools := d.Get(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)).([]interface{})[0].(map[string]interface{})
 		poolSpec := nodepools[SpecKey].([]interface{})[0].(map[string]interface{})
-		// poolInfo := nodepools["info"].([]interface{})[0].(map[string]interface{})
 		tkgsSpec := poolSpec[tkgServiceVsphereKey].([]interface{})[0].(map[string]interface{})
 
 		if d.HasChange(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)) {

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -597,7 +597,6 @@ func withTKGNodePoolUpdate(d *schema.ResourceData, nodepool *nodepoolmodel.Vmwar
 		tkgsSpec := poolSpec[tkgServiceVsphereKey].([]interface{})[0].(map[string]interface{})
 
 		if d.HasChange(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)) {
-
 			incomingWorkerNodeCount := poolSpec[workerNodeCountKey].(string)
 
 			if incomingWorkerNodeCount != "" {

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -102,7 +102,7 @@ func constructFullname(d *schema.ResourceData) (fullname *clustermodel.VmwareTan
 	return fullname
 }
 
-func constructNpFullName(d *schema.ResourceData) (fullname *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolFullName) {
+func constructNodePoolFullName(d *schema.ResourceData) (fullname *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolFullName) {
 	fullname = &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolFullName{}
 
 	if value, ok := d.GetOk(ManagementClusterNameKey); ok {
@@ -676,7 +676,7 @@ func resourceClusterInPlaceUpdate(ctx context.Context, d *schema.ResourceData, m
 		log.Printf("[INFO] cluster update successful")
 	}
 	// check default nodepool configuration update
-	npFullName := constructNpFullName(d)
+	npFullName := constructNodePoolFullName(d)
 
 	npResp, err := config.TMCConnection.NodePoolResourceService.ManageV1alpha1ClusterNodePoolResourceServiceGet(npFullName)
 	if err != nil {

--- a/internal/resources/cluster/resource_cluster.go
+++ b/internal/resources/cluster/resource_cluster.go
@@ -24,6 +24,8 @@ import (
 	clienterrors "github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/errors"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
 	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	nodepoolmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster/nodepool"
+
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/manifest"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/tkgaws"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/tkgservicevsphere"
@@ -96,6 +98,29 @@ func constructFullname(d *schema.ResourceData) (fullname *clustermodel.VmwareTan
 	fullname.ManagementClusterName, _ = d.Get(ManagementClusterNameKey).(string)
 	fullname.ProvisionerName, _ = d.Get(ProvisionerNameKey).(string)
 	fullname.Name, _ = d.Get(NameKey).(string)
+
+	return fullname
+}
+
+func constructNpFullName(d *schema.ResourceData) (fullname *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolFullName) {
+	fullname = &nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolFullName{}
+
+	if value, ok := d.GetOk(ManagementClusterNameKey); ok {
+		fullname.ManagementClusterName = value.(string)
+	}
+
+	if value, ok := d.GetOk(ProvisionerNameKey); ok {
+		fullname.ProvisionerName = value.(string)
+	}
+
+	if value, ok := d.GetOk(NameKey); ok {
+		fullname.ClusterName = value.(string)
+	}
+
+	if value, ok := d.Get(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)).([]interface{})[0].(map[string]interface{}); ok {
+		poolInfo := value["info"].([]interface{})[0].(map[string]interface{})
+		fullname.Name = poolInfo["name"].(string)
+	}
 
 	return fullname
 }
@@ -563,6 +588,51 @@ func withMetaUpdate(d *schema.ResourceData, cluster *clustermodel.VmwareTanzuMan
 	return true
 }
 
+func withTKGNodePoolUpdate(d *schema.ResourceData, nodepool *nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolNodepool) bool {
+
+	switch {
+	case nodepool.Spec.TkgServiceVsphere != nil:
+		nodepools := d.Get(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)).([]interface{})[0].(map[string]interface{})
+		poolSpec := nodepools[SpecKey].([]interface{})[0].(map[string]interface{})
+		// poolInfo := nodepools["info"].([]interface{})[0].(map[string]interface{})
+		tkgsSpec := poolSpec[tkgServiceVsphereKey].([]interface{})[0].(map[string]interface{})
+		if d.HasChange(helper.GetFirstElementOf(SpecKey, tkgServiceVsphereKey, topologyKey, nodePoolKey)) {
+
+			incomingWorkerNodeCount := poolSpec[workerNodeCountKey].(string)
+
+			if incomingWorkerNodeCount != "" {
+				nodepool.Spec.WorkerNodeCount = incomingWorkerNodeCount
+			}
+
+			incomingTkgServiceVsphereClass := tkgsSpec[classKey].(string)
+
+			if incomingTkgServiceVsphereClass != "" {
+				nodepool.Spec.TkgServiceVsphere.Class = incomingTkgServiceVsphereClass
+			}
+
+			incomingTkgServiceVsphereStorageClass := tkgsSpec[storageClassKey].(string)
+
+			if incomingTkgServiceVsphereStorageClass != "" {
+				nodepool.Spec.TkgServiceVsphere.StorageClass = incomingTkgServiceVsphereStorageClass
+			}
+			log.Printf("[INFO] updating TKGs workload cluster nodepools")
+			return true
+		}
+	case nodepool.Spec.TkgVsphere != nil:
+		nodepools := d.Get(helper.GetFirstElementOf(SpecKey, tkgVsphereClusterKey, topologyKey, nodePoolKey)).([]interface{})[0].(map[string]interface{})
+		poolSpec := nodepools[SpecKey].([]interface{})[0].(map[string]interface{})
+		if d.HasChange(helper.GetFirstElementOf(SpecKey, tkgVsphereClusterKey, topologyKey, nodePoolKey)) {
+			incomingWorkerNodeCount := poolSpec[workerNodeCountKey].(string)
+
+			if incomingWorkerNodeCount != "" {
+				nodepool.Spec.WorkerNodeCount = incomingWorkerNodeCount
+			}
+		}
+	}
+
+	return false
+}
+
 func resourceClusterInPlaceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	config := m.(authctx.TanzuContext)
 
@@ -593,6 +663,25 @@ func resourceClusterInPlaceUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		log.Printf("[INFO] cluster update successful")
+	}
+	//check default nodepool configuration update
+	npFullName := constructNpFullName(d)
+	npResp, err := config.TMCConnection.NodePoolResourceService.ManageV1alpha1ClusterNodePoolResourceServiceGet(npFullName)
+	if err != nil {
+		return diag.FromErr(errors.Wrapf(err, "Unable to get Tanzu Mission Control cluster node pool entry, name : %s", npFullName.Name))
+	}
+
+	if withTKGNodePoolUpdate(d, npResp.Nodepool) {
+		_, err = config.TMCConnection.NodePoolResourceService.ManageV1alpha1ClusterNodePoolResourceServiceUpdate(
+			&nodepoolmodel.VmwareTanzuManageV1alpha1ClusterNodepoolCreateNodepoolRequest{
+				Nodepool: npResp.Nodepool,
+			},
+		)
+		if err != nil {
+			return diag.FromErr(errors.Wrapf(err, "Unable to update tanzu cluster node pool entry"))
+		}
+
+		log.Printf("[INFO] node pool update successful")
 	}
 
 	return dataSourceClusterRead(ctx, d, m)


### PR DESCRIPTION
1. **What this PR does / why we need it**:

This adds the logic needed to be able to update certain settings on the default node pool through the cluster resource for TKGs and TKGm. This is not for cluster class based clusters.