### PR TITLE
Add note to tanzu-mission-control_cluster resource guide to state the limitation

### DIFF
--- a/docs/guides/tanzu-mission-control_cluster.md
+++ b/docs/guides/tanzu-mission-control_cluster.md
@@ -12,6 +12,10 @@ With Tanzu Kubernetes clusters, you can also provision resources to create new w
 
 Before creating a Tanzu Kubernetes Grid Service workload cluster in vSphere with Tanzu using this Terraform provider we need the following prerequisites.
 
+~> **Note:**
+Current version of `tanzu-mission-control_cluster` resource in Tanzu Mission Control provider supports creation of deafult nodepool and updates to some fields specifically `worker_node_count, class, storage_class` in case of Tanzu Kubernetes Grid Service workload cluster and updation of `worker_node_count` in case Tanzu Kubernetes Grid vSphere Workload Cluster of default nodepool. Deletion of the default nodepool is not yet supported via this resource and will be added in the upcoming releases.
+All other nodepools except the default nodepool can be managed via `tanzu-mission-control_cluster_node_pool` resource.
+
 **Prerequisites:**
 
 - Register the Tanzu Kubernetes Grid Service management cluster in Tanzu Mission Control.

--- a/templates/guides/tanzu-mission-control_cluster.md.tmpl
+++ b/templates/guides/tanzu-mission-control_cluster.md.tmpl
@@ -12,6 +12,10 @@ With Tanzu Kubernetes clusters, you can also provision resources to create new w
 
 Before creating a Tanzu Kubernetes Grid Service workload cluster in vSphere with Tanzu using this Terraform provider we need the following prerequisites.
 
+~> **Note:**
+Current version of `tanzu-mission-control_cluster` resource in Tanzu Mission Control provider supports creation of deafult nodepool and updates to some fields specifically `worker_node_count, class, storage_class` in case of Tanzu Kubernetes Grid Service workload cluster and updation of `worker_node_count` in case Tanzu Kubernetes Grid vSphere Workload Cluster of default nodepool. Deletion of the default nodepool is not yet supported via this resource and will be added in the upcoming releases.
+All other nodepools except the default nodepool can be managed via `tanzu-mission-control_cluster_node_pool` resource.
+
 **Prerequisites:**
 
 - Register the Tanzu Kubernetes Grid Service management cluster in Tanzu Mission Control.


### PR DESCRIPTION

1. **What this PR does / why we need it**:
     This is a follow up PR to https://github.com/vmware/terraform-provider-tanzu-mission-control/pull/328 , stating the resource limitation which prevent the deletion of default nodepool using terraform.
2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->