### PR TITLE
Add jsonencode for clustervariables and nodepool overrides in the tazukubernetescluster resource acceptance tests

### DIFF
--- a/internal/resources/tanzukubernetescluster/tests/resource_tf_configs.go
+++ b/internal/resources/tanzukubernetescluster/tests/resource_tf_configs.go
@@ -39,7 +39,7 @@ func InitResourceTFConfigBuilder() *ResourceTFConfigBuilder {
 			spec {
 			  worker_class = "%s"
 			  replicas     = 1
-			  overrides    = "%s"
+			  overrides    = jsonencode(%s)
 	
 			  meta {
 				labels      = { "key" : "value" }
@@ -74,7 +74,7 @@ func (builder *ResourceTFConfigBuilder) GetTKGMClusterConfig(tkgmEnvVars map[Clu
 			topology {
 			  version           = "%s"
 			  cluster_class     = "%s"
-			  cluster_variables = "%s"
+			  cluster_variables = jsonencode(%s)
 		
 			  control_plane {
 				replicas = 1
@@ -154,7 +154,7 @@ func (builder *ResourceTFConfigBuilder) GetTKGSClusterConfig(tkgsEnvVars map[Clu
 			topology {
 			  version           = "%s"
 			  cluster_class     = "%s"
-			  cluster_variables = "%s"
+			  cluster_variables = jsonencode(%s)
 		
 			  control_plane {
 				replicas = 1


### PR DESCRIPTION


1. **What this PR does / why we need it**:
      Test fix to include jsonencode for clusterclass variables

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**
    Test log:
```
<testsuite name="github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing" tests="0" failures="0" errors="0" id="215" hostname="sc2-10-43-229-72.nimbus.eng.vmware.com" time="0.000" timestamp="2023-12-11T17:14:52Z"></testsuite>
	<testsuite name="github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/tanzukubernetescluster/tests" tests="1" failures="0" errors="0" id="216" hostname="sc2-10-43-229-72.nimbus.eng.vmware.com" time="1806.351" timestamp="2023-12-11T17:44:53Z">
		<testcase name="TestAcceptanceUTKGResource" classname="github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/tanzukubernetescluster/tests" time="1806.320">
			<system-out><![CDATA[    tanzu_kubernetes_cluster_test.go:106: Tanzu kubernetes cluster resource acceptance test complete!]]></system-out>
		</testcase>
		<system-out><![CDATA[	github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/tanzukubernetescluster/tests	coverage: 89.7% of statements]]></system-out>
	</testsuite>
```

4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->