### PR TITLE
EKS wait for management cluster and pinniped to be healthy and set kubeconfig when wait_for_kubeconfig is set to true

### DIFF
--- a/docs/data-sources/ekscluster.md
+++ b/docs/data-sources/ekscluster.md
@@ -48,10 +48,12 @@ data "tanzu-mission-control_ekscluster" "tf_eks_cluster" {
 - `meta` (Block List, Max: 1) Metadata for the resource (see [below for nested schema](#nestedblock--meta))
 - `ready_wait_timeout` (String) Wait timeout duration until cluster resource reaches READY state. Accepted timeout duration values like 5s, 45m, or 3h, higher than zero
 - `spec` (Block List, Max: 1) Spec for the cluster (see [below for nested schema](#nestedblock--spec))
+- `wait_for_kubeconfig` (Boolean) Wait until pinniped extension is ready to provide kubeconfig
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `kubeconfig` (String) Kubeconfig for connecting to newly created cluster base64 encoded. This will only be returned if you have elected to wait for kubeconfig.
 - `status` (Map of String) Status of the cluster
 
 <a id="nestedblock--meta"></a>

--- a/docs/resources/ekscluster.md
+++ b/docs/resources/ekscluster.md
@@ -80,22 +80,19 @@ resource "tanzu-mission-control_ekscluster" "tf_eks_cluster" {
         ]
       }
 
-      addons_config {
+      addons_config { // this whole section is optional
         vpc_cni_config {
           eni_config {
-            id = "subnet-0a680171b6330619f" // Required, should belong to the same VPC as the cluster
-            security_groups = [
+            id = "subnet-0a680171b6330619f" // Required, need not belong to the same VPC as the cluster, subnets provided in vpc_cni_config are expected to be in different AZs
+            security_groups = [ //optional, if not provided, the cluster security group will be used
               "sg-00c96ad9d02a22522",
             ]
           }
           eni_config {
-            id = "subnet-06feb0bb0451cda78" // Required, should belong to the same VPC as the cluster
-            security_groups = [
-              "sg-00c96ad9d02a22522",
-            ]
+            id = "subnet-06feb0bb0451cda79" // Required, need not belong to the same VPC as the cluster, subnets provided in vpc_cni_config are expected to be in different AZs
           }
         }
-      }      
+      }
     }
 
     nodepool {
@@ -213,10 +210,12 @@ resource "tanzu-mission-control_ekscluster" "tf_eks_cluster" {
 - `meta` (Block List, Max: 1) Metadata for the resource (see [below for nested schema](#nestedblock--meta))
 - `ready_wait_timeout` (String) Wait timeout duration until cluster resource reaches READY state. Accepted timeout duration values like 5s, 45m, or 3h, higher than zero
 - `spec` (Block List, Max: 1) Spec for the cluster (see [below for nested schema](#nestedblock--spec))
+- `wait_for_kubeconfig` (Boolean) Wait until pinniped extension is ready to provide kubeconfig
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `kubeconfig` (String) Kubeconfig for connecting to newly created cluster base64 encoded. This will only be returned if you have elected to wait for kubeconfig.
 - `status` (Map of String) Status of the cluster
 
 <a id="nestedblock--meta"></a>
@@ -283,14 +282,14 @@ Optional:
 
 Optional:
 
-- `vpc_cni_config` (Block List, Max: 1) VPC CNI addon config contains the configuration for the VPC CNI addon of the cluster. (see [below for nested schema](#nestedblock--spec--config--addons_config--vpc_cni_config))
+- `vpc_cni_config` (Block List, Max: 1) VPC CNI addon config contains the configuration for the VPC CNI addon of the cluster (see [below for nested schema](#nestedblock--spec--config--addons_config--vpc_cni_config))
 
 <a id="nestedblock--spec--config--addons_config--vpc_cni_config"></a>
 ### Nested Schema for `spec.config.addons_config.vpc_cni_config`
 
 Optional:
 
-- `eni_config` (Block List) ENI config is the VPC CNI Elastic Network Interface config for providing the configuration of subnet and security groups for pods in each AZ.  Subnets need not be in the same VPC as the cluster. The subnets provided across eniConfigs should be in different availability zones. Nodepool subnets need to be in the same AZ as the AZs used in ENIConfig. (see [below for nested schema](#nestedblock--spec--config--addons_config--vpc_cni_config--eni_config))
+- `eni_config` (Block List) ENI config is the VPC CNI Elastic Network Interface config for providing the configuration of subnet and security groups for pods in each AZ.  Subnets need not be in the same VPC as the cluster. The subnets provided across eniConfigs should be in different availability zones. Nodepool subnets need to be in the same AZ as the AZs used in ENIConfig.  (see [below for nested schema](#nestedblock--spec--config--addons_config--vpc_cni_config--eni_config))
 
 <a id="nestedblock--spec--config--addons_config--vpc_cni_config--eni_config"></a>
 ### Nested Schema for `spec.config.addons_config.vpc_cni_config.eni_config`
@@ -301,7 +300,7 @@ Required:
 
 Optional:
 
-- `security_groups` (Set of String) List of security group is optional and if not provided default security group created by EKS will be used. 
+- `security_groups` (Set of String) List of security group is optional and if not provided default security group created by EKS will be used.
 
 
 

--- a/internal/models/ekscluster/spec.go
+++ b/internal/models/ekscluster/spec.go
@@ -28,6 +28,12 @@ type VmwareTanzuManageV1alpha1EksclusterSpec struct {
 	// Optional proxy name is the name of the Proxy Config
 	// to be used for the cluster.
 	ProxyName string `json:"proxyName,omitempty"`
+
+	// Agent name of the cluster.
+	AgentName string `json:"agentName,omitempty"`
+
+	// Arn of the cluster.
+	Arn string `json:"arn,omitempty"`
 }
 
 // MarshalBinary interface implementation

--- a/internal/resources/ekscluster/constants.go
+++ b/internal/resources/ekscluster/constants.go
@@ -69,4 +69,6 @@ const (
 	releaseVersionKey           = "release_version"
 	readyCondition              = "Ready"
 	errorSeverity               = "ERROR"
+	waitForKubeconfig           = "wait_for_kubeconfig"
+	kubeconfigKey               = "kubeconfig"
 )

--- a/internal/resources/ekscluster/data_source.go
+++ b/internal/resources/ekscluster/data_source.go
@@ -10,8 +10,6 @@ import (
 	"log"
 	"strconv"
 	"time"
-	// "os"
-	// "strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -84,19 +82,18 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 			return true, nil
 		}
 
-		// if val := os.Getenv("WAIT_FOR_HEALTHY"); strings.EqualFold(val, "TRUE") || val == "" {
 		if isWaitForKubeconfig(d) {
-			clusFullName := &clustermodel.VmwareTanzuManageV1alpha1ClusterFullName { Name: resp.EksCluster.Spec.AgentName, OrgID: clusterFn.OrgID, ManagementClusterName: "eks", ProvisionerName: "eks" }
+			clusFullName := &clustermodel.VmwareTanzuManageV1alpha1ClusterFullName{Name: resp.EksCluster.Spec.AgentName, OrgID: clusterFn.OrgID, ManagementClusterName: "eks", ProvisionerName: "eks"}
 			clusterResp, err := config.TMCConnection.ClusterResourceService.ManageV1alpha1ClusterResourceServiceGet(clusFullName)
 			if err != nil {
 				log.Printf("Unable to get Tanzu Mission Control cluster entry, name : %s", clusterFn.Name)
 			}
-	
+
 			if !isManagemetClusterHealthy(clusterResp) {
 				log.Printf("[DEBUG] waiting for cluster(%s) to be in Healthy status", clusterFn.Name)
 				return true, nil
 			}
-			
+
 			fn := &configModels.VmwareTanzuManageV1alpha1ClusterFullName{
 				ManagementClusterName: "eks",
 				ProvisionerName:       "eks",
@@ -112,7 +109,7 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 				}
 			}
 		}
-		
+
 		return false, nil
 	}
 
@@ -159,7 +156,7 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 }
 
 func isManagemetClusterHealthy(cluster *clustermodel.VmwareTanzuManageV1alpha1ClusterGetClusterResponse) bool {
-	return cluster.Cluster.Status.Health != nil && *cluster.Cluster.Status.Health == clustermodel.VmwareTanzuManageV1alpha1CommonClusterHealthHEALTHY 
+	return cluster.Cluster.Status.Health != nil && *cluster.Cluster.Status.Health == clustermodel.VmwareTanzuManageV1alpha1CommonClusterHealthHEALTHY
 }
 
 func kubeConfigReady(err error, resp *configModels.VmwareTanzuManageV1alpha1ClusterKubeconfigGetKubeconfigResponse) bool {

--- a/internal/resources/ekscluster/data_source.go
+++ b/internal/resources/ekscluster/data_source.go
@@ -84,10 +84,10 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 
 		if isWaitForKubeconfig(d) {
 			clusFullName := &clustermodel.VmwareTanzuManageV1alpha1ClusterFullName{
-				Name: resp.EksCluster.Spec.AgentName, 
-				OrgID: clusterFn.OrgID, 
-				ManagementClusterName: "eks", 
-				ProvisionerName: "eks",
+				Name:                  resp.EksCluster.Spec.AgentName,
+				OrgID:                 clusterFn.OrgID,
+				ManagementClusterName: "eks",
+				ProvisionerName:       "eks",
 			}
 			clusterResp, err := config.TMCConnection.ClusterResourceService.ManageV1alpha1ClusterResourceServiceGet(clusFullName)
 			// nolint: wsl
@@ -100,11 +100,9 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 			if err != nil {
 				log.Printf("[DEBUG] waiting for cluster(%s) to be in Healthy status", clusterFn.Name)
 				return true, nil
-			} else {
-				if !mgmtClusterHealthy {
-					log.Printf("[DEBUG] waiting for cluster(%s) to be in Healthy status", clusterFn.Name)
-					return true, nil
-				}
+			} else if !mgmtClusterHealthy {
+				log.Printf("[DEBUG] waiting for cluster(%s) to be in Healthy status", clusterFn.Name)
+				return true, nil
 			}
 
 			fn := &configModels.VmwareTanzuManageV1alpha1ClusterFullName{
@@ -113,6 +111,7 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 				Name:                  resp.EksCluster.Spec.AgentName,
 			}
 			resp, err := config.TMCConnection.KubeConfigResourceService.KubeconfigServiceGet(fn)
+			// nolint: wsl
 			if err != nil {
 				log.Printf("Unable to get Tanzu Mission Control Kubeconfig entry, name : %s, error :  %s", fn.Name, err.Error())
 				return true, err

--- a/internal/resources/ekscluster/data_source.go
+++ b/internal/resources/ekscluster/data_source.go
@@ -85,6 +85,7 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 		if isWaitForKubeconfig(d) {
 			clusFullName := &clustermodel.VmwareTanzuManageV1alpha1ClusterFullName{Name: resp.EksCluster.Spec.AgentName, OrgID: clusterFn.OrgID, ManagementClusterName: "eks", ProvisionerName: "eks"}
 			clusterResp, err := config.TMCConnection.ClusterResourceService.ManageV1alpha1ClusterResourceServiceGet(clusFullName)
+			// nolint: wsl
 			if err != nil {
 				log.Printf("Unable to get Tanzu Mission Control cluster entry, name : %s", clusterFn.Name)
 				return true, nil

--- a/internal/resources/ekscluster/data_source.go
+++ b/internal/resources/ekscluster/data_source.go
@@ -87,6 +87,7 @@ func dataSourceTMCEKSClusterRead(ctx context.Context, d *schema.ResourceData, m 
 			clusterResp, err := config.TMCConnection.ClusterResourceService.ManageV1alpha1ClusterResourceServiceGet(clusFullName)
 			if err != nil {
 				log.Printf("Unable to get Tanzu Mission Control cluster entry, name : %s", clusterFn.Name)
+				return true, nil
 			}
 
 			if !isManagemetClusterHealthy(clusterResp) {

--- a/internal/resources/ekscluster/data_source_test.go
+++ b/internal/resources/ekscluster/data_source_test.go
@@ -107,7 +107,7 @@ func TestIsManagemetClusterHealthy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := isManagemetClusterHealthy(test.cluster)
+			result, err := isClusterHealthy(test.cluster)
 			if err != nil {
 				if err.Error() != test.err.Error() {
 					t.Errorf("expected error to match")

--- a/internal/resources/ekscluster/data_source_test.go
+++ b/internal/resources/ekscluster/data_source_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	eksmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/ekscluster"
 	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
+	eksmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/ekscluster"
 )
 
 func TestNodepoolPosMap(t *testing.T) {
@@ -63,10 +63,10 @@ func TestNodepoolPosMap(t *testing.T) {
 
 func TestIsManagemetClusterHealthy(t *testing.T) {
 	tests := []struct {
-		name    string
-		cluster *clustermodel.VmwareTanzuManageV1alpha1ClusterGetClusterResponse
+		name     string
+		cluster  *clustermodel.VmwareTanzuManageV1alpha1ClusterGetClusterResponse
 		response bool
-		err     error
+		err      error
 	}{
 		{
 			name: "Not healthy",
@@ -78,7 +78,7 @@ func TestIsManagemetClusterHealthy(t *testing.T) {
 				},
 			},
 			response: false,
-			err: nil,
+			err:      nil,
 		},
 		{
 			name: "Healthy",
@@ -88,9 +88,9 @@ func TestIsManagemetClusterHealthy(t *testing.T) {
 						Health: clustermodel.NewVmwareTanzuManageV1alpha1CommonClusterHealth(clustermodel.VmwareTanzuManageV1alpha1CommonClusterHealthHEALTHY),
 					},
 				},
-			},		
-			response: true,	
-			err: nil,
+			},
+			response: true,
+			err:      nil,
 		},
 	}
 

--- a/internal/resources/ekscluster/data_source_test.go
+++ b/internal/resources/ekscluster/data_source_test.go
@@ -1,6 +1,3 @@
-//go:build ekscluster
-// +build ekscluster
-
 /*
 Copyright 2022 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: MPL-2.0
@@ -14,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	eksmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/ekscluster"
+	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
 )
 
 func TestNodepoolPosMap(t *testing.T) {
@@ -59,6 +57,48 @@ func TestNodepoolPosMap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.res, nodepoolPosMap(test.nps), "expected function output to match")
+		})
+	}
+}
+
+func TestIsManagemetClusterHealthy(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *clustermodel.VmwareTanzuManageV1alpha1ClusterGetClusterResponse
+		response bool
+		err     error
+	}{
+		{
+			name: "Not healthy",
+			cluster: &clustermodel.VmwareTanzuManageV1alpha1ClusterGetClusterResponse{
+				Cluster: &clustermodel.VmwareTanzuManageV1alpha1ClusterCluster{
+					Status: &clustermodel.VmwareTanzuManageV1alpha1ClusterStatus{
+						Health: clustermodel.NewVmwareTanzuManageV1alpha1CommonClusterHealth(clustermodel.VmwareTanzuManageV1alpha1CommonClusterHealthUNHEALTHY),
+					},
+				},
+			},
+			response: false,
+			err: nil,
+		},
+		{
+			name: "Healthy",
+			cluster: &clustermodel.VmwareTanzuManageV1alpha1ClusterGetClusterResponse{
+				Cluster: &clustermodel.VmwareTanzuManageV1alpha1ClusterCluster{
+					Status: &clustermodel.VmwareTanzuManageV1alpha1ClusterStatus{
+						Health: clustermodel.NewVmwareTanzuManageV1alpha1CommonClusterHealth(clustermodel.VmwareTanzuManageV1alpha1CommonClusterHealthHEALTHY),
+					},
+				},
+			},		
+			response: true,	
+			err: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.response != isManagemetClusterHealthy(test.cluster) {
+				t.Errorf("expected function output to match")
+			}
 		})
 	}
 }

--- a/internal/resources/ekscluster/data_source_test.go
+++ b/internal/resources/ekscluster/data_source_test.go
@@ -8,6 +8,7 @@ package ekscluster
 import (
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	clustermodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/cluster"
@@ -92,11 +93,26 @@ func TestIsManagemetClusterHealthy(t *testing.T) {
 			response: true,
 			err:      nil,
 		},
+		{
+			name: "Error",
+			cluster: &clustermodel.VmwareTanzuManageV1alpha1ClusterGetClusterResponse{
+				Cluster: &clustermodel.VmwareTanzuManageV1alpha1ClusterCluster{
+					Status: nil,
+				},
+			},
+			response: false,
+			err:      errors.New("cluster data is invalid or nil"),
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.response != isManagemetClusterHealthy(test.cluster) {
+			result, err := isManagemetClusterHealthy(test.cluster)
+			if err != nil {
+				if err.Error() != test.err.Error() {
+					t.Errorf("expected error to match")
+				}
+			} else if test.response != result {
 				t.Errorf("expected function output to match")
 			}
 		})

--- a/internal/resources/ekscluster/resource_ekscluster.go
+++ b/internal/resources/ekscluster/resource_ekscluster.go
@@ -96,7 +96,7 @@ var clusterSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Description: "Kubeconfig for connecting to newly created cluster base64 encoded. This will only be returned if you have elected to wait for kubeconfig.",
 		Computed:    true,
-	},	
+	},
 }
 
 var clusterSpecSchema = &schema.Schema{

--- a/internal/resources/ekscluster/resource_ekscluster.go
+++ b/internal/resources/ekscluster/resource_ekscluster.go
@@ -86,6 +86,17 @@ var clusterSchema = map[string]*schema.Schema{
 			return true
 		},
 	},
+	waitForKubeconfig: {
+		Type:        schema.TypeBool,
+		Description: "Wait until pinniped extension is ready to provide kubeconfig",
+		Default:     false,
+		Optional:    true,
+	},
+	kubeconfigKey: {
+		Type:        schema.TypeString,
+		Description: "Kubeconfig for connecting to newly created cluster base64 encoded. This will only be returned if you have elected to wait for kubeconfig.",
+		Computed:    true,
+	},	
 }
 
 var clusterSpecSchema = &schema.Schema{
@@ -957,4 +968,13 @@ func flattenEniConfig(item *eksmodel.VmwareTanzuManageV1alpha1EksclusterEniConfi
 	data[securityGroupsKey] = item.SecurityGroupIds
 
 	return data
+}
+
+func isWaitForKubeconfig(data *schema.ResourceData) bool {
+	v := data.Get(waitForKubeconfig)
+	if v != nil {
+		return v.(bool)
+	}
+
+	return false
 }


### PR DESCRIPTION
1. **What this PR does / why we need it**:
EKS wait for management cluster and pinniped to be healthy and set kubeconfig when wait_for_kubeconfig is set to true

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes # TMC-43744


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->