### PR TITLE
Fix the backup schedule datasource schema and the broken converter mapping

### DIFF
--- a/internal/resources/cluster/backupschedule/converter_mapping.go
+++ b/internal/resources/cluster/backupschedule/converter_mapping.go
@@ -125,15 +125,12 @@ var tfModelDataSourceRequestMap = &tfModelConverterHelper.BlockToStruct{
 	SortByKey:            "sortBy",
 	QueryKey:             "query",
 	IncludeTotalCountKey: "includeTotal",
-	NameKey:              tfModelConverterHelper.BuildDefaultModelPath("fullName", "name"),
+	NameKey:              tfModelConverterHelper.BuildDefaultModelPath("searchScope", "name"),
 	ScopeKey: &tfModelConverterHelper.BlockToStruct{
-		ClusterGroupScopeKey: &tfModelConverterHelper.BlockToStruct{
-			ClusterGroupNameKey: tfModelConverterHelper.BuildDefaultModelPath("fullName", "clusterGroupName"),
-		},
 		ClusterScopeKey: &tfModelConverterHelper.BlockToStruct{
-			ClusterNameKey:           tfModelConverterHelper.BuildDefaultModelPath("fullName", "clusterName"),
-			ManagementClusterNameKey: tfModelConverterHelper.BuildDefaultModelPath("fullName", "managementClusterName"),
-			ProvisionerNameKey:       tfModelConverterHelper.BuildDefaultModelPath("fullName", "provisionerName"),
+			ClusterNameKey:           tfModelConverterHelper.BuildDefaultModelPath("searchScope", "clusterName"),
+			ManagementClusterNameKey: tfModelConverterHelper.BuildDefaultModelPath("searchScope", "managementClusterName"),
+			ProvisionerNameKey:       tfModelConverterHelper.BuildDefaultModelPath("searchScope", "provisionerName"),
 		},
 	},
 }

--- a/internal/resources/cluster/backupschedule/datasource_schema.go
+++ b/internal/resources/cluster/backupschedule/datasource_schema.go
@@ -26,22 +26,19 @@ var (
 	nameDSSchema = &schema.Schema{
 		Type:        schema.TypeString,
 		Description: "The name of the backup schedule",
-		Required:    true,
-		ForceNew:    true,
+		Optional:    true,
 	}
 
 	managementClusterNameDSSchema = &schema.Schema{
 		Type:        schema.TypeString,
 		Description: "Management cluster name",
-		Required:    true,
-		ForceNew:    true,
+		Optional:    true,
 	}
 
 	provisionerNameDSSchema = &schema.Schema{
 		Type:        schema.TypeString,
 		Description: "Cluster provisioner name",
-		Required:    true,
-		ForceNew:    true,
+		Optional:    true,
 	}
 
 	sortBySchema = &schema.Schema{


### PR DESCRIPTION

1. **What this PR does / why we need it**:
 While introducing the scope block the datasource schema and the converter mapping was broken . This pull request will fix those issues 

3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**


5. **Special notes for your reviewer**

```
/GoLand/___1TestAcceptanceBackupScheduleResource_in_github_com_vmware_terraform_provider_tanzu_mission_control_internal_resources_cluster_backupschedule_tests.test github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster/backupschedule/tests #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/pz/0s95qff529d4v3n6zsrbp1340000gq/T/GoLand/___1TestAcceptanceBackupScheduleResource_in_github_com_vmware_terraform_provider_tanzu_mission_control_internal_resources_cluster_backupschedule_tests.test -test.v -test.paniconexit0 -test.run ^\QTestAcceptanceBackupScheduleResource\E$
=== RUN   TestAcceptanceBackupScheduleResource
TMC resources applied to the cluster successfully
    backup_schedule_test.go:94: backup schedule resource acceptance test complete!
--- PASS: TestAcceptanceBackupScheduleResource (331.29s)
PASS

Process finished with the exit code 0
```