### PR TITLE
Add support for aks managed identities

### DIFF
--- a/docs/data-sources/akscluster.md
+++ b/docs/data-sources/akscluster.md
@@ -109,6 +109,7 @@ Optional:
 - `api_server_access_config` (Block List, Max: 1) API Server Access Config (see [below for nested schema](#nestedblock--spec--config--api_server_access_config))
 - `auto_upgrade_config` (Block List, Max: 1) Auto Upgrade Config (see [below for nested schema](#nestedblock--spec--config--auto_upgrade_config))
 - `disk_encryption_set` (String) Resource ID of the disk encryption set to use for enabling
+- `identity_config` (Block List, Max: 1) Managed Identity Config (see [below for nested schema](#nestedblock--spec--config--identity_config))
 - `linux_config` (Block List, Max: 1) Linux Config (see [below for nested schema](#nestedblock--spec--config--linux_config))
 - `node_resource_group_name` (String) Name of the resource group containing nodepools.
 - `sku` (Block List, Max: 1) Azure Kubernetes Service SKU (see [below for nested schema](#nestedblock--spec--config--sku))
@@ -210,6 +211,23 @@ Optional:
 Optional:
 
 - `upgrade_channel` (String) Upgrade Channel. Allowed values include: NONE, PATCH, STABLE, RAPID or NODE_IMAGE
+
+
+<a id="nestedblock--spec--config--identity_config"></a>
+### Nested Schema for `spec.config.identity_config`
+
+Optional:
+
+- `type` (String) Type of managed identity used by the cluster (default IDENTITY_TYPE_SYSTEM_ASSIGNED). Allowed values include: IDENTITY_TYPE_SYSTEM_ASSIGNED or IDENTITY_TYPE_USER_ASSIGNED
+- `user_assigned` (Block List, Max: 1) User Assigned Managed Identity Config (see [below for nested schema](#nestedblock--spec--config--identity_config--user_assigned))
+
+<a id="nestedblock--spec--config--identity_config--user_assigned"></a>
+### Nested Schema for `spec.config.identity_config.user_assigned`
+
+Required:
+
+- `resource_id` (String) The ARM resource ID of user assigned identity in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'
+
 
 
 <a id="nestedblock--spec--config--linux_config"></a>

--- a/docs/resources/akscluster.md
+++ b/docs/resources/akscluster.md
@@ -130,6 +130,7 @@ Optional:
 - `api_server_access_config` (Block List, Max: 1) API Server Access Config (see [below for nested schema](#nestedblock--spec--config--api_server_access_config))
 - `auto_upgrade_config` (Block List, Max: 1) Auto Upgrade Config (see [below for nested schema](#nestedblock--spec--config--auto_upgrade_config))
 - `disk_encryption_set` (String) Resource ID of the disk encryption set to use for enabling
+- `identity_config` (Block List, Max: 1) Managed Identity Config (see [below for nested schema](#nestedblock--spec--config--identity_config))
 - `linux_config` (Block List, Max: 1) Linux Config (see [below for nested schema](#nestedblock--spec--config--linux_config))
 - `node_resource_group_name` (String) Name of the resource group containing nodepools.
 - `sku` (Block List, Max: 1) Azure Kubernetes Service SKU (see [below for nested schema](#nestedblock--spec--config--sku))
@@ -231,6 +232,23 @@ Optional:
 Optional:
 
 - `upgrade_channel` (String) Upgrade Channel. Allowed values include: NONE, PATCH, STABLE, RAPID or NODE_IMAGE
+
+
+<a id="nestedblock--spec--config--identity_config"></a>
+### Nested Schema for `spec.config.identity_config`
+
+Optional:
+
+- `type` (String) Type of managed identity used by the cluster (default IDENTITY_TYPE_SYSTEM_ASSIGNED). Allowed values include: IDENTITY_TYPE_SYSTEM_ASSIGNED or IDENTITY_TYPE_USER_ASSIGNED
+- `user_assigned` (Block List, Max: 1) User Assigned Managed Identity Config (see [below for nested schema](#nestedblock--spec--config--identity_config--user_assigned))
+
+<a id="nestedblock--spec--config--identity_config--user_assigned"></a>
+### Nested Schema for `spec.config.identity_config.user_assigned`
+
+Required:
+
+- `resource_id` (String) The ARM resource ID of user assigned identity in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'
+
 
 
 <a id="nestedblock--spec--config--linux_config"></a>

--- a/internal/models/akscluster/cluster_config.go
+++ b/internal/models/akscluster/cluster_config.go
@@ -50,6 +50,9 @@ type VmwareTanzuManageV1alpha1AksclusterClusterConfig struct {
 	// The metadata to apply to the cluster to assist with categorization and organization.
 	Tags map[string]string `json:"tags,omitempty"`
 
+	// The managed identity to apply to the cluster.
+	IdentityConfig *VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig `json:"identityConfig,omitempty"`
+
 	// Kubernetes version of the cluster.
 	Version string `json:"version,omitempty"`
 }

--- a/internal/models/akscluster/managed_identity_config.go
+++ b/internal/models/akscluster/managed_identity_config.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package models
+
+import "github.com/go-openapi/swag"
+
+// VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig The managed identity config.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.akscluster.ManagedIdentityConfig
+type VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig struct {
+	Type *VmwareTanzuManageV1alpha1AksclusterManagedIdentityType `json:"type,omitempty"`
+
+	UserAssignedIdentityType *VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig `json:"userAssigned,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/models/akscluster/managed_identity_type.go
+++ b/internal/models/akscluster/managed_identity_type.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+)
+
+// VmwareTanzuManageV1alpha1AksclusterManagedIdentityType Managed identity type options of identity config.
+//
+//   - IDENTITY_TYPE_SYSTEM_ASSIGNED: Indicates that a system assigned managed identity should be used by the cluster.
+//   - IDENTITY_TYPE_USER_ASSIGNED: Indicates that a user assigned managed identity should be used by the cluster.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.akscluster.ManagedIdentityType
+type VmwareTanzuManageV1alpha1AksclusterManagedIdentityType string
+
+func NewVmwareTanzuManageV1alpha1AksclusterManagedIdentityType(value VmwareTanzuManageV1alpha1AksclusterManagedIdentityType) *VmwareTanzuManageV1alpha1AksclusterManagedIdentityType {
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated VmwareTanzuManageV1alpha1AksclusterManagedIdentityType.
+func (m VmwareTanzuManageV1alpha1AksclusterManagedIdentityType) Pointer() *VmwareTanzuManageV1alpha1AksclusterManagedIdentityType {
+	return &m
+}
+
+const (
+
+	// VmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeSYSTEMASSIGNED captures enum value "IDENTITY_TYPE_SYSTEM_ASSIGNED".
+	VmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeSYSTEMASSIGNED VmwareTanzuManageV1alpha1AksclusterManagedIdentityType = "IDENTITY_TYPE_SYSTEM_ASSIGNED"
+
+	// VmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeUSERASSIGNED captures enum value "IDENTITY_TYPE_USER_ASSIGNED".
+	VmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeUSERASSIGNED VmwareTanzuManageV1alpha1AksclusterManagedIdentityType = "IDENTITY_TYPE_USER_ASSIGNED"
+)
+
+// for schema.
+var vmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeEnum []interface{}
+
+func init() {
+	var res []VmwareTanzuManageV1alpha1AksclusterManagedIdentityType
+	if err := json.Unmarshal([]byte(`["IDENTITY_TYPE_SYSTEM_ASSIGNED","IDENTITY_TYPE_USER_ASSIGNED"]`), &res); err != nil {
+		panic(err)
+	}
+
+	for _, v := range res {
+		vmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeEnum = append(vmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeEnum, v)
+	}
+}

--- a/internal/models/akscluster/user_assigned_identity_config.go
+++ b/internal/models/akscluster/user_assigned_identity_config.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package models
+
+import "github.com/go-openapi/swag"
+
+// VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig The managed identity config.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.akscluster.UserAssignedIdentityTypeConfig
+
+type VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig struct {
+	ManagedResourceID string `json:"resourceId,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/resources/akscluster/akscluster_mapper.go
+++ b/internal/resources/akscluster/akscluster_mapper.go
@@ -140,6 +140,11 @@ func constructConfig(data []any) *models.VmwareTanzuManageV1alpha1AksclusterClus
 		helper.SetPrimitiveValue(v, &config.NodeResourceGroupName, nodeResourceGroupNameKey)
 	}
 
+	if v, ok := configData[identityConfigKey]; ok {
+		data, _ := v.([]any)
+		config.IdentityConfig = constructManagedIdentityConfig(data)
+	}
+
 	return config
 }
 
@@ -433,6 +438,44 @@ func constructAutoUpgradeConfig(data []any) *models.VmwareTanzuManageV1alpha1Aks
 	return autoUpgradeConfig
 }
 
+func constructManagedIdentityConfig(data []any) *models.VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig {
+	if len(data) < 1 {
+		return nil
+	}
+
+	// ManagedIdentityConfig schema defines max 1
+	managedIdentityConfigData, _ := data[0].(map[string]any)
+	managedIdentityConfig := &models.VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig{}
+
+	if v, ok := managedIdentityConfigData[typeKey]; ok {
+		identityType := models.VmwareTanzuManageV1alpha1AksclusterManagedIdentityType(v.(string))
+		managedIdentityConfig.Type = &identityType
+	}
+
+	if v, ok := managedIdentityConfigData[userAssignedKey]; ok {
+		data, _ := v.([]any)
+		managedIdentityConfig.UserAssignedIdentityType = constructUserAssignedIdentityConfig(data)
+	}
+
+	return managedIdentityConfig
+}
+
+func constructUserAssignedIdentityConfig(data []any) *models.VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig {
+	if len(data) < 1 {
+		return nil
+	}
+
+	// UserAssignedIdentityConfig schema defines max 1
+	userAssignedIdentityConfigData, _ := data[0].(map[string]any)
+	userAssignedIdentityConfig := &models.VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig{}
+
+	if v, ok := userAssignedIdentityConfigData[resourceIDKey]; ok {
+		helper.SetPrimitiveValue(v, &userAssignedIdentityConfig.ManagedResourceID, resourceIDKey)
+	}
+
+	return userAssignedIdentityConfig
+}
+
 func ToAKSClusterMap(cluster *models.VmwareTanzuManageV1alpha1AksCluster, nodepools []*models.VmwareTanzuManageV1alpha1AksclusterNodepoolNodepool) any {
 	if cluster == nil {
 		return []any{}
@@ -483,6 +526,7 @@ func toConfigMap(config *models.VmwareTanzuManageV1alpha1AksclusterClusterConfig
 	data[storageConfigKey] = toStorageConfigMap(config.StorageConfig)
 	data[addonsConfigKey] = toAddonConfigMap(config.AddonsConfig)
 	data[autoUpgradeConfigKey] = toAutoUpgradeConfigMap(config.AutoUpgradeConfig)
+	data[identityConfigKey] = toManagedIdentityConfigMap(config.IdentityConfig)
 
 	return []any{data}
 }
@@ -638,6 +682,29 @@ func toAutoUpgradeConfigMap(config *models.VmwareTanzuManageV1alpha1AksclusterAu
 
 	data := make(map[string]any)
 	data[upgradeChannelKey] = helper.PtrString(config.Channel)
+
+	return []any{data}
+}
+
+func toManagedIdentityConfigMap(config *models.VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig) []any {
+	if config == nil {
+		return []any{}
+	}
+
+	data := make(map[string]any)
+	data[typeKey] = helper.PtrString(config.Type)
+	data[userAssignedKey] = toUserAssignedIdentityTypeConfigMap(config.UserAssignedIdentityType)
+
+	return []any{data}
+}
+
+func toUserAssignedIdentityTypeConfigMap(config *models.VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig) []any {
+	if config == nil {
+		return []any{}
+	}
+
+	data := make(map[string]any)
+	data[resourceIDKey] = config.ManagedResourceID
 
 	return []any{data}
 }

--- a/internal/resources/akscluster/constants.go
+++ b/internal/resources/akscluster/constants.go
@@ -106,4 +106,6 @@ const (
 	upgradeConfigKey                           = "upgrade_config"
 	maxSurgeKey                                = "max_surge"
 	kubeconfigKey                              = "kubeconfig"
+	identityConfigKey                          = "identity_config"
+	userAssignedKey                            = "user_assigned"
 )

--- a/internal/resources/akscluster/helpers_test.go
+++ b/internal/resources/akscluster/helpers_test.go
@@ -372,6 +372,7 @@ func aTestClusterDataMap(w ...mapWither) map[string]any {
 				"auto_upgrade_config": []any{map[string]any{
 					"upgrade_channel": "STABLE",
 				}},
+				"identity_config": []any{},
 			}},
 			"nodepool": []any{
 				aTestNodepoolDataMap(),

--- a/internal/resources/akscluster/helpers_test.go
+++ b/internal/resources/akscluster/helpers_test.go
@@ -159,6 +159,12 @@ func aTestCluster(w ...clusterWither) *models.VmwareTanzuManageV1alpha1AksCluste
 				AutoUpgradeConfig: &models.VmwareTanzuManageV1alpha1AksclusterAutoUpgradeConfig{
 					Channel: models.VmwareTanzuManageV1alpha1AksclusterChannelSTABLE.Pointer(),
 				},
+				IdentityConfig: &models.VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig{
+					Type: models.VmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeUSERASSIGNED.Pointer(),
+					UserAssignedIdentityType: &models.VmwareTanzuManageV1alpha1AksclusterUserAssignedIdentityTypeConfig{
+						ManagedResourceID: "resource-id-for-a-user-assigned-managed-identity",
+					},
+				},
 			},
 			ProxyName:  "my-proxy",
 			AgentName:  "my-agent-name",
@@ -372,7 +378,12 @@ func aTestClusterDataMap(w ...mapWither) map[string]any {
 				"auto_upgrade_config": []any{map[string]any{
 					"upgrade_channel": "STABLE",
 				}},
-				"identity_config": []any{},
+				"identity_config": []any{map[string]any{
+					"type": "IDENTITY_TYPE_USER_ASSIGNED",
+					"user_assigned": []any{map[string]any{
+						"resource_id": "resource-id-for-a-user-assigned-managed-identity",
+					}},
+				}},
 			}},
 			"nodepool": []any{
 				aTestNodepoolDataMap(),

--- a/internal/resources/akscluster/schema.go
+++ b/internal/resources/akscluster/schema.go
@@ -205,6 +205,13 @@ var ClusterConfig = &schema.Resource{
 			MaxItems:    1,
 			Elem:        AutoUpgradeConfig,
 		},
+		identityConfigKey: {
+			Type:        schema.TypeList,
+			Description: "Managed Identity Config",
+			Optional:    true,
+			MaxItems:    1,
+			Elem:        ManagedIdentityConfig,
+		},
 	},
 }
 
@@ -510,6 +517,38 @@ var AutoUpgradeConfig = &schema.Resource{
 				string(aksmodel.VmwareTanzuManageV1alpha1AksclusterChannelRAPID),
 				string(aksmodel.VmwareTanzuManageV1alpha1AksclusterChannelNODEIMAGE),
 			}, false)),
+		},
+	},
+}
+
+var ManagedIdentityConfig = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		typeKey: {
+			Type:        schema.TypeString,
+			Description: "Type of managed identity used by the cluster (default IDENTITY_TYPE_SYSTEM_ASSIGNED). Allowed values include: IDENTITY_TYPE_SYSTEM_ASSIGNED or IDENTITY_TYPE_USER_ASSIGNED",
+			Optional:    true,
+			Default:     "IDENTITY_TYPE_SYSTEM_ASSIGNED",
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+				string(aksmodel.VmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeSYSTEMASSIGNED),
+				string(aksmodel.VmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeUSERASSIGNED),
+			}, false)),
+		},
+		userAssignedKey: {
+			Type:        schema.TypeList,
+			Description: "User Assigned Managed Identity Config",
+			Optional:    true,
+			MaxItems:    1,
+			Elem:        UserAssignedManagedIdentityConfig,
+		},
+	},
+}
+
+var UserAssignedManagedIdentityConfig = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		resourceIDKey: {
+			Type:        schema.TypeString,
+			Description: "The ARM resource ID of user assigned identity in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'",
+			Required:    true,
 		},
 	},
 }


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Support managed identities specification when creating and updating AKS clusters

2. **Which issue(s) this PR fixes**

N/A

3. **Additional information**

When using `terraform apply` a user can provide a `identity_config` section within the cluster config section of the terraform plan file. Here they can specify whether a system or user assigned managed identity is to be used for the cluster.

The default if an `identity_config` is not provide will be use a system assigned managed identity.

4. **Special notes for your reviewer**

Changes were tested by creating and modifying clusters on Olympus dev stack. Scenarios tested are summarized below:

- No identity_config struct specified: **SUCCESS -> Cluster with system assigned MI**
- Empty identity_config struct: **SUCCESS -> Cluster with system assigned MI -> Defaults to system assigned MI in terraform plan**
- identity_config struct with type `IDENTITY_TYPE_SYSTEM_ASSIGNED`: **SUCCESS -> Cluster with system assigned MI**
---
- identity_config struct with type `IDENTITY_TYPE_USER_ASSIGNED` and no userAssigned struct: **ERROR -> No cluster -> Expected behavior, see Terraform test - User assigned identity with no userAssigned struct attachment**
- identity_config struct with type `IDENTITY_TYPE_USER_ASSIGNED` and empty userAssigned struct: **ERROR -> No cluster -> Expected behavior, see Terraform test - User assigned identity with empty struct attachment**
- identity_config struct with type `IDENTITY_TYPE_USER_ASSIGNED` and populated userAssigned struct, invalid identity: **ERROR -> No cluster -> Expected behavior, see Terraform test - User assigned identity with invalid identity attachment**
- identity_config struct with type `IDENTITY_TYPE_USER_ASSIGNED` and populated userAssigned struct, valid identity: **SUCCESS -> Cluster with user assigned MI**
---
- Create cluster with system assigned MI: **SUCCESS**
- Create cluster with user assigned MI: **SUCCESS**
- Create cluster with system assigned MI, then change to a user assigned MI: **SUCCESS -> List aks clusters now shows user assigned identity for cluster**
- Create cluster with system assigned MI, then change to a user assigned MI, then change back to a system assigned MI: **SUCCESS -> List aks cluster shows system assigned identity again for cluster; SYSTEM -> USER -> SYSTEM**
- Create cluster with user assigned MI, then change to a system assigned MI: **SUCCESS -> List aks clusters now shows system assigned identity for cluster**
- Create cluster with user assigned MI, then change to a system assigned MI, then change back to user assigned MI: **SUCCESS -> List aks cluster shows user assigned identity again for cluster; USER -> SYSTEM -> USER**
---
Terraform test - User assigned identity with no userAssigned struct:
![Terraform test - User assigned identity with no userAssigned struct](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/16089977/3a885ea5-eb95-45f9-bcb9-3d869179682f)

Terraform test - User assigned identity with empty struct
![Terraform test - User assigned identity with empty struct](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/16089977/7c789e67-a5ed-43f6-a616-f2d42b057bde)

Terraform test - User assigned identity with invalid identity
![Terraform test - User assigned identity with invalid identity](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/16089977/e6b4870a-c77a-4376-9861-21faa18d21be)
