### PR TITLE
Resource and data source acceptance test for provisioner resource

### DIFF
--- a/internal/resources/provisioner/constants.go
+++ b/internal/resources/provisioner/constants.go
@@ -6,9 +6,12 @@ SPDX-License-Identifier: MPL-2.0
 package provisioner
 
 const (
-	ResourceName = "tanzu-mission-control_provisioner"
+	ResourceName  = "tanzu-mission-control_provisioner"
+	resourceVar   = "provisioner_resource"
+	dataSourceVar = "provisioner_data_source"
 
 	nameKey                  = "name"
 	orgIDKey                 = "org_id"
 	managementClusterNameKey = "management_cluster"
+	eksManagementCluster     = "eks"
 )

--- a/internal/resources/provisioner/provisioner_data_source_test.go
+++ b/internal/resources/provisioner/provisioner_data_source_test.go
@@ -1,0 +1,90 @@
+//go:build provisioner
+// +build provisioner
+
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package provisioner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
+)
+
+func TestAcceptanceForProvisionerDataSource(t *testing.T) {
+	var provider = initTestProvider(t)
+
+	provisionerResourceName := fmt.Sprintf("%s.%s", ResourceName, resourceVar)
+	provisionerName := acctest.RandomWithPrefix("tf-prv-test")
+
+	provisionerDataSource := fmt.Sprintf("data.%s.%s", ResourceName, dataSourceVar)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testhelper.TestPreCheck(t),
+		ProviderFactories: testhelper.GetTestProviderFactories(provider),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: getTestProvisionerWithDataSourceConfigValue(provisionerName),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceAttributes(provisionerDataSource, provisionerResourceName),
+				),
+			},
+		},
+	})
+}
+
+func getTestProvisionerWithDataSourceConfigValue(prvName string) string {
+	return fmt.Sprintf(`
+	resource "%s" "%s" {
+		name = "%s"
+		management_cluster = "%s"
+		%s
+	}
+
+	data "%s" "%s" {
+		name = tanzu-mission-control_provisioner.provisioner_resource.name
+		management_cluster = tanzu-mission-control_provisioner.provisioner_resource.management_cluster
+	}
+	`, ResourceName, resourceVar, prvName, eksManagementCluster, testhelper.MetaTemplate, ResourceName, dataSourceVar)
+}
+
+func checkDataSourceAttributes(dataSourceName, resourceName string) resource.TestCheckFunc {
+	var check = []resource.TestCheckFunc{
+		verifyProvisionerDataSource(dataSourceName),
+		resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+	}
+
+	check = append(check, metaDataSourceAttributeCheck(dataSourceName, resourceName)...)
+
+	return resource.ComposeTestCheckFunc(check...)
+}
+
+func verifyProvisionerDataSource(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module does not have provisioner resource %s", name)
+		}
+
+		return nil
+	}
+}
+
+func metaDataSourceAttributeCheck(dataSourceName, resourceName string) []resource.TestCheckFunc {
+	return []resource.TestCheckFunc{
+		resource.TestCheckResourceAttrPair(dataSourceName, "meta.0.description", resourceName, "meta.0.description"),
+		resource.TestCheckResourceAttrPair(dataSourceName, "meta.0.labels.key1", resourceName, "meta.0.labels.key1"),
+		resource.TestCheckResourceAttrPair(dataSourceName, "meta.0.labels.key2", resourceName, "meta.0.labels.key2"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "meta.0.uid"),
+	}
+}

--- a/internal/resources/provisioner/provisioner_provider_test.go
+++ b/internal/resources/provisioner/provisioner_provider_test.go
@@ -1,0 +1,36 @@
+//go:build provisioner
+// +build provisioner
+
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+)
+
+func initTestProvider(t *testing.T) *schema.Provider {
+	testAccProvider := &schema.Provider{
+		Schema: authctx.ProviderAuthSchema(),
+		ResourcesMap: map[string]*schema.Resource{
+			ResourceName: ResourceProvisioner(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			ResourceName: DataSourceProvisioner(),
+		},
+		ConfigureContextFunc: authctx.ProviderConfigureContext,
+	}
+	if err := testAccProvider.InternalValidate(); err != nil {
+		require.NoError(t, err)
+	}
+
+	return testAccProvider
+}

--- a/internal/resources/provisioner/provisioner_resource_test.go
+++ b/internal/resources/provisioner/provisioner_resource_test.go
@@ -1,0 +1,126 @@
+//go:build provisioner
+// +build provisioner
+
+/*
+Copyright © 2023 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package provisioner
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/pkg/errors"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/client/proxy"
+	provisioner "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/provisioner"
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
+)
+
+func TestAcceptanceForProvisionerResource(t *testing.T) {
+	var provider = initTestProvider(t)
+
+	provisionerResourceName := fmt.Sprintf("%s.%s", ResourceName, resourceVar)
+	provisionerName := acctest.RandomWithPrefix("tf-prv-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testhelper.TestPreCheck(t),
+		ProviderFactories: testhelper.GetTestProviderFactories(provider),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: getTestProvisionerWithResourceConfigValue(provisionerName),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceAttributes(provider, provisionerResourceName, provisionerName),
+				),
+			},
+		},
+	})
+}
+
+func checkResourceAttributes(provider *schema.Provider, resourceName, prvName string) resource.TestCheckFunc {
+	var check = []resource.TestCheckFunc{
+		verifyProvisionerResourceCreation(provider, resourceName, prvName),
+	}
+
+	check = append(check, metaResourceAttributeCheck(resourceName)...)
+
+	return resource.ComposeTestCheckFunc(check...)
+}
+
+func getTestProvisionerWithResourceConfigValue(prvName string) string {
+	return fmt.Sprintf(`
+	resource "%s" "%s" {
+		name = "%s"
+		management_cluster = "%s"
+		%s
+	}
+	`, ResourceName, resourceVar, prvName, eksManagementCluster, testhelper.MetaTemplate)
+}
+
+func verifyProvisionerResourceCreation(
+	provider *schema.Provider,
+	resourceName string,
+	provisionerName string,
+) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if provider == nil {
+			return fmt.Errorf("provider not initialised")
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found resource: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("ID not set, resource: %s", resourceName)
+		}
+
+		config := authctx.TanzuContext{
+			ServerEndpoint:   os.Getenv(authctx.ServerEndpointEnvVar),
+			Token:            os.Getenv(authctx.VMWCloudAPITokenEnvVar),
+			VMWCloudEndPoint: os.Getenv(authctx.VMWCloudEndpointEnvVar),
+			TLSConfig:        &proxy.TLSConfig{},
+		}
+
+		err := config.Setup()
+		if err != nil {
+			return errors.Wrap(err, "unable to set the context")
+		}
+
+		fn := &provisioner.VmwareTanzuManageV1alpha1ManagementclusterProvisionerFullName{
+			ManagementClusterName: "eks",
+			Name:                  provisionerName,
+		}
+
+		resp, err := config.TMCConnection.ProvisionerResourceService.ProvisionerResourceServiceGet(fn)
+		if err != nil {
+			return errors.Wrap(err, "provisioner resource not found")
+		}
+
+		if resp == nil {
+			return errors.Wrapf(err, "provisioner resource is empty, resource: %s", resourceName)
+		}
+
+		return nil
+	}
+}
+
+func metaResourceAttributeCheck(resourceName string) []resource.TestCheckFunc {
+	return []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "meta.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "meta.0.description", "resource with description"),
+		resource.TestCheckResourceAttr(resourceName, "meta.0.labels.key1", "value1"),
+		resource.TestCheckResourceAttr(resourceName, "meta.0.labels.key2", "value2"),
+		resource.TestCheckResourceAttrSet(resourceName, "meta.0.uid"),
+	}
+}


### PR DESCRIPTION
1. **What this PR does / why we need it**:  Resource and data source acceptance test for provisioner resource

<img width="902" alt="Screenshot 2023-12-22 at 1 12 50 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/47659349/16d2a646-824e-4047-b402-b4ac661c07c1">


<img width="907" alt="Screenshot 2023-12-22 at 1 13 37 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/47659349/4c4a4e64-b458-49b6-8a8c-8b3179b6a8ce">


3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->