### PR TITLE
Applied cluster tags to nodepools, don't report this as a terraform change

### DIFF
--- a/internal/resources/ekscluster/data_source.go
+++ b/internal/resources/ekscluster/data_source.go
@@ -178,6 +178,7 @@ func setResourceData(d *schema.ResourceData, eksCluster *eksmodel.VmwareTanzuMan
 	if err := d.Set(specKey, spec); err != nil {
 		return errors.Wrapf(err, "Failed to set the spec for cluster %s", eksCluster.FullName.Name)
 	}
+
 	return nil
 }
 

--- a/internal/resources/ekscluster/helpers.go
+++ b/internal/resources/ekscluster/helpers.go
@@ -199,6 +199,7 @@ func copyClusterTagsToNodepools(nodepoolTags map[string]string, eksTags map[stri
 	if len(nodepoolTags) > 0 {
 		npTags = nodepoolTags
 	}
+
 	for tmcTag, tmcVal := range eksTags {
 		if _, ok := npTags[tmcTag]; !ok {
 			npTags[tmcTag] = tmcVal

--- a/internal/resources/ekscluster/helpers.go
+++ b/internal/resources/ekscluster/helpers.go
@@ -193,3 +193,17 @@ func setEquality(s1, s2 []string) bool {
 
 	return true
 }
+
+func copyClusterTagsToNodepools(nodepoolTags map[string]string, eksTags map[string]string) map[string]string {
+	npTags := make(map[string]string)
+	if len(nodepoolTags) > 0 {
+		npTags = nodepoolTags
+	}
+	for tmcTag, tmcVal := range eksTags {
+		if _, ok := npTags[tmcTag]; !ok {
+			npTags[tmcTag] = tmcVal
+		}
+	}
+
+	return npTags
+}

--- a/internal/resources/ekscluster/helpers.go
+++ b/internal/resources/ekscluster/helpers.go
@@ -7,6 +7,8 @@ package ekscluster
 import (
 	"reflect"
 
+	"github.com/pkg/errors"
+
 	eksmodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/ekscluster"
 )
 
@@ -194,17 +196,22 @@ func setEquality(s1, s2 []string) bool {
 	return true
 }
 
-func copyClusterTagsToNodepools(nodepoolTags map[string]string, eksTags map[string]string) map[string]string {
+func copyClusterTagsToNodepools(nodepoolTags map[string]string, eksTags map[string]string) (map[string]string, error) {
 	npTags := make(map[string]string)
+
+	var err error
+
 	if len(nodepoolTags) > 0 {
 		npTags = nodepoolTags
 	}
 
 	for tmcTag, tmcVal := range eksTags {
-		if _, ok := npTags[tmcTag]; !ok {
+		if val, ok := npTags[tmcTag]; !ok {
 			npTags[tmcTag] = tmcVal
+		} else if val == tmcVal {
+			err = errors.Errorf("key:%v, val:%v", tmcTag, val)
 		}
 	}
 
-	return npTags
+	return npTags, err
 }

--- a/internal/resources/ekscluster/resource_ekscluster.go
+++ b/internal/resources/ekscluster/resource_ekscluster.go
@@ -590,6 +590,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, m interf
 	for _, npDefData := range nps {
 		npDefData.Spec.Tags = copyClusterTagsToNodepools(npDefData.Spec.Tags, clusterSpec.Config.Tags)
 	}
+
 	clusterReq := &eksmodel.VmwareTanzuManageV1alpha1EksclusterCreateUpdateEksClusterRequest{
 		EksCluster: &eksmodel.VmwareTanzuManageV1alpha1EksclusterEksCluster{
 			FullName: clusterFn,
@@ -733,6 +734,7 @@ func resourceClusterImporter(ctx context.Context, d *schema.ResourceData, m inte
 	if err = d.Set(NameKey, resp.EksCluster.FullName.Name); err != nil {
 		return nil, errors.Wrapf(err, "Failed to set name for the cluster %s", resp.EksCluster.FullName.Name)
 	}
+
 	err = setResourceData(d, resp.EksCluster, npresp.Nodepools)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to set resource data during import for %s", resp.EksCluster.FullName.Name)

--- a/internal/resources/ekscluster/resource_ekscluster.go
+++ b/internal/resources/ekscluster/resource_ekscluster.go
@@ -495,7 +495,7 @@ func constructAddonsConfig(data []interface{}) *eksmodel.VmwareTanzuManageV1alph
 	addonsConfig := &eksmodel.VmwareTanzuManageV1alpha1EksclusterAddonsConfig{}
 
 	if len(data) == 0 || data[0] == nil {
-		return addonsConfig
+		return nil
 	}
 
 	addonsConfigData, _ := data[0].(map[string]interface{})

--- a/internal/resources/ekscluster/resource_ekscluster_test.go
+++ b/internal/resources/ekscluster/resource_ekscluster_test.go
@@ -422,9 +422,8 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 				RoleArn: controlPlaneRoleARN,
 				Tags: map[string]string{
 					"tmc.cloud.vmware.com/tmc-managed": "true",
-					"testclustertag":                   "testclustertagvalue",
-					"testingtag":                       "testingtagvalue",
-					"testsametag":                      "testsametagval",
+					"testtag":                          "testval",
+					"newtesttag":                       "newtestval",
 				},
 				KubernetesNetworkConfig: &eksmodel.VmwareTanzuManageV1alpha1EksclusterKubernetesNetworkConfig{
 					ServiceCidr: "10.100.0.0/16",
@@ -470,10 +469,9 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 					CapacityType: "ON_DEMAND",
 					RootDiskSize: 40,
 					Tags: map[string]string{
-						"testnptag":      "testnptagvalue",
-						"testingtag":     "testingnptagvalue",
-						"testsametag":    "testsametagval",
-						"testclustertag": "testclustertagvalue",
+						"testnptag":  "testnptagvalue",
+						"newtesttag": "testingtagvalue",
+						"testtag":    "testval",
 					},
 					NodeLabels: map[string]string{
 						"testnplabelkey": "testnplabelvalue",
@@ -514,10 +512,9 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 				Spec: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolSpec{
 					RoleArn: workerRoleArn,
 					Tags: map[string]string{
-						"testnptag":      "testnptagvalue",
-						"testingtag":     "testingnptagvalue",
-						"testsametag":    "testsametagval",
-						"testclustertag": "testclustertagvalue",
+						"testnptag":  "testnptagvalue",
+						"newtesttag": "testingtagvalue",
+						"testtag":    "testval",
 					},
 					NodeLabels: map[string]string{
 						"testnplabelkey": "testnplabelvalue",

--- a/internal/resources/ekscluster/resource_ekscluster_test.go
+++ b/internal/resources/ekscluster/resource_ekscluster_test.go
@@ -422,6 +422,9 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 				RoleArn: controlPlaneRoleARN,
 				Tags: map[string]string{
 					"tmc.cloud.vmware.com/tmc-managed": "true",
+					"testclustertag":                   "testclustertagvalue",
+					"testingtag":                       "testingtagvalue",
+					"testsametag":                      "testsametagval",
 				},
 				KubernetesNetworkConfig: &eksmodel.VmwareTanzuManageV1alpha1EksclusterKubernetesNetworkConfig{
 					ServiceCidr: "10.100.0.0/16",
@@ -467,7 +470,10 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 					CapacityType: "ON_DEMAND",
 					RootDiskSize: 40,
 					Tags: map[string]string{
-						"testnptag": "testnptagvalue",
+						"testnptag":      "testnptagvalue",
+						"testingtag":     "testingnptagvalue",
+						"testsametag":    "testsametagval",
+						"testclustertag": "testclustertagvalue",
 					},
 					NodeLabels: map[string]string{
 						"testnplabelkey": "testnplabelvalue",
@@ -508,7 +514,10 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 				Spec: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolSpec{
 					RoleArn: workerRoleArn,
 					Tags: map[string]string{
-						"testnptag": "testnptagvalue",
+						"testnptag":      "testnptagvalue",
+						"testingtag":     "testingnptagvalue",
+						"testsametag":    "testsametagval",
+						"testclustertag": "testclustertagvalue",
 					},
 					NodeLabels: map[string]string{
 						"testnplabelkey": "testnplabelvalue",

--- a/internal/resources/ekscluster/resource_nodepool.go
+++ b/internal/resources/ekscluster/resource_nodepool.go
@@ -350,7 +350,6 @@ func flattenSpec(item *eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolSpec)
 	if len(item.SubnetIds) > 0 {
 		data[subnetIdsKey] = item.SubnetIds
 	}
-
 	data[tagsKey] = item.Tags
 
 	if len(item.Taints) > 0 {

--- a/internal/resources/ekscluster/resource_nodepool.go
+++ b/internal/resources/ekscluster/resource_nodepool.go
@@ -350,6 +350,7 @@ func flattenSpec(item *eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolSpec)
 	if len(item.SubnetIds) > 0 {
 		data[subnetIdsKey] = item.SubnetIds
 	}
+
 	data[tagsKey] = item.Tags
 
 	if len(item.Taints) > 0 {

--- a/internal/resources/testing/test_config.go
+++ b/internal/resources/testing/test_config.go
@@ -18,6 +18,7 @@ const testDefaultCreateEksClusterScript = `
 			config {
 				kubernetes_version 	= "{{.KubernetesVersion}}"
 				role_arn 			= "arn:aws:iam::{{.AWSAccountNumber}}:role/control-plane.{{.CloudFormationTemplateID}}.eks.tmc.cloud.vmware.com"
+				tags           = { "testclustertag" : "testclustertagvalue", "testingtag": "testingtagvalue", "testsametag":"testsametagval"}
 				kubernetes_network_config {
 					service_cidr = "10.100.0.0/16" // Forces new
 				}
@@ -35,13 +36,13 @@ const testDefaultCreateEksClusterScript = `
 					  "0.0.0.0/0",
 					]
 					security_groups = [ // Forces new
-					  "sg-0b77767aa25e20fec",
+					  "sg-0a6768722e9716768",
 					]
 					subnet_ids = [ // Forces new
-					  "subnet-0c285da60b373a4cc",
-					  "subnet-0be854d94fa197cb7",
-					  "subnet-04975d535cf761785",
-					  "subnet-0d50aa17c694457c9",
+					  	"subnet-0a184f6302af32a86",
+						"subnet-0ed95d5c212ac62a1",
+						"subnet-0526ecaecde5b1bf7",
+						"subnet-06897e1063cc0cf4e",
 					]
 				}
 			}
@@ -54,22 +55,29 @@ const testDefaultCreateEksClusterScript = `
 				spec {
 					// Refer to nodepool's schema
 					role_arn       = "arn:aws:iam::{{.AWSAccountNumber}}:role/worker.{{.CloudFormationTemplateID}}.eks.tmc.cloud.vmware.com"
-					ami_type       = "AL2_x86_64" // Forces New
+					ami_type       = "CUSTOM" // Forces New
 					capacity_type  = "ON_DEMAND"
-					root_disk_size = 20 // Default: 20GiB, forces New
-					tags           = { "testnptag" : "testnptagvalue" }
+					ami_info { 
+						ami_id = "ami-2qu8409oisdfj0qw"
+                        override_bootstrap_cmd = "#!/bin/bash\n/etc/eks/bootstrap.sh tf-test-ami"
+					}
+					remote_access {
+                        ssh_key = "anshulc"
+						security_groups = ["sg-0a6768722e9716768"]
+					}
+					root_disk_size = 40 // Default: 20GiB, forces New
+					tags           = { "testnptag" : "testnptagvalue", "testingtag": "testingnptagvalue"}
 					node_labels    = { "testnplabelkey" : "testnplabelvalue" }
 					subnet_ids = [ // Required, forces new
-						"subnet-0c285da60b373a4cc",
-						"subnet-0be854d94fa197cb7",
-						"subnet-04975d535cf761785",
-						"subnet-0d50aa17c694457c9",
+						"subnet-0a184f6302af32a86",
+						"subnet-0ed95d5c212ac62a1",
+						"subnet-0526ecaecde5b1bf7",
+						"subnet-06897e1063cc0cf4e",
 					]
-					
 					scaling_config  {
-						desired_size = 2
-						max_size     = 2
-						min_size     = 2
+						desired_size = 4
+						max_size     = 8
+						min_size     = 1
 					}
 					update_config {
 						max_unavailable_nodes = "2"
@@ -89,13 +97,17 @@ const testDefaultCreateEksClusterScript = `
 				spec  {
 					// Refer to nodepool's schema
 					role_arn    = "arn:aws:iam::{{.AWSAccountNumber}}:role/worker.{{.CloudFormationTemplateID}}.eks.tmc.cloud.vmware.com"
-					tags        = { "testnptag" : "testnptagvalue" }
+					tags        = { "testnptag" : "testnptagvalue", "testingtag": "testingnptagvalue"}
 					node_labels = { "testnplabelkey" : "testnplabelvalue" }
+					launch_template {
+						name = "PLACE_HOLDER"
+						version = "PLACE_HOLDER"
+					}
 					subnet_ids = [ // Required, forces new
-						"subnet-0c285da60b373a4cc",
-						"subnet-0be854d94fa197cb7",
-						"subnet-04975d535cf761785",
-						"subnet-0d50aa17c694457c9",
+						"subnet-0a184f6302af32a86",
+						"subnet-0ed95d5c212ac62a1",
+						"subnet-0526ecaecde5b1bf7",
+						"subnet-06897e1063cc0cf4e",
 					]
 					scaling_config  {
 						desired_size = 4

--- a/internal/resources/testing/test_config.go
+++ b/internal/resources/testing/test_config.go
@@ -18,7 +18,7 @@ const testDefaultCreateEksClusterScript = `
 			config {
 				kubernetes_version 	= "{{.KubernetesVersion}}"
 				role_arn 			= "arn:aws:iam::{{.AWSAccountNumber}}:role/control-plane.{{.CloudFormationTemplateID}}.eks.tmc.cloud.vmware.com"
-				tags           = { "testclustertag" : "testclustertagvalue", "testingtag": "testingtagvalue", "testsametag":"testsametagval"}
+				tags           = { "testtag" : "testval", "newtesttag": "newtestval"}
 				kubernetes_network_config {
 					service_cidr = "10.100.0.0/16" // Forces new
 				}
@@ -66,7 +66,7 @@ const testDefaultCreateEksClusterScript = `
 						security_groups = ["sg-0a6768722e9716768"]
 					}
 					root_disk_size = 40 // Default: 20GiB, forces New
-					tags           = { "testnptag" : "testnptagvalue", "testingtag": "testingnptagvalue"}
+					tags           = { "testnptag" : "testnptagvalue", "newtesttag": "testingtagvalue"}
 					node_labels    = { "testnplabelkey" : "testnplabelvalue" }
 					subnet_ids = [ // Required, forces new
 						"subnet-0a184f6302af32a86",
@@ -97,7 +97,7 @@ const testDefaultCreateEksClusterScript = `
 				spec  {
 					// Refer to nodepool's schema
 					role_arn    = "arn:aws:iam::{{.AWSAccountNumber}}:role/worker.{{.CloudFormationTemplateID}}.eks.tmc.cloud.vmware.com"
-					tags        = { "testnptag" : "testnptagvalue", "testingtag": "testingnptagvalue"}
+					tags        = { "testnptag" : "testnptagvalue", "newtesttag": "testingtagvalue"}
 					node_labels = { "testnplabelkey" : "testnplabelvalue" }
 					launch_template {
 						name = "PLACE_HOLDER"

--- a/internal/resources/testing/test_config.go
+++ b/internal/resources/testing/test_config.go
@@ -36,13 +36,10 @@ const testDefaultCreateEksClusterScript = `
 					  "0.0.0.0/0",
 					]
 					security_groups = [ // Forces new
-					  "sg-0a6768722e9716768",
+					  "sg-09247a89b01962bd9",
 					]
 					subnet_ids = [ // Forces new
-					  	"subnet-0a184f6302af32a86",
-						"subnet-0ed95d5c212ac62a1",
-						"subnet-0526ecaecde5b1bf7",
-						"subnet-06897e1063cc0cf4e",
+					  	"subnet-0e3bcd8e3c06a4bf0", "subnet-06427cefa730aeae7", "subnet-07c17b758e92356f6", "subnet-0a081ddc6ff1070d0"
 					]
 				}
 			}
@@ -55,24 +52,13 @@ const testDefaultCreateEksClusterScript = `
 				spec {
 					// Refer to nodepool's schema
 					role_arn       = "arn:aws:iam::{{.AWSAccountNumber}}:role/worker.{{.CloudFormationTemplateID}}.eks.tmc.cloud.vmware.com"
-					ami_type       = "CUSTOM" // Forces New
+					ami_type       = "AL2_x86_64" // Forces New
 					capacity_type  = "ON_DEMAND"
-					ami_info { 
-						ami_id = "ami-2qu8409oisdfj0qw"
-                        override_bootstrap_cmd = "#!/bin/bash\n/etc/eks/bootstrap.sh tf-test-ami"
-					}
-					remote_access {
-                        ssh_key = "anshulc"
-						security_groups = ["sg-0a6768722e9716768"]
-					}
 					root_disk_size = 40 // Default: 20GiB, forces New
 					tags           = { "testnptag" : "testnptagvalue", "newtesttag": "testingtagvalue"}
 					node_labels    = { "testnplabelkey" : "testnplabelvalue" }
 					subnet_ids = [ // Required, forces new
-						"subnet-0a184f6302af32a86",
-						"subnet-0ed95d5c212ac62a1",
-						"subnet-0526ecaecde5b1bf7",
-						"subnet-06897e1063cc0cf4e",
+						"subnet-0e3bcd8e3c06a4bf0", "subnet-06427cefa730aeae7", "subnet-07c17b758e92356f6", "subnet-0a081ddc6ff1070d0"
 					]
 					scaling_config  {
 						desired_size = 4
@@ -99,15 +85,8 @@ const testDefaultCreateEksClusterScript = `
 					role_arn    = "arn:aws:iam::{{.AWSAccountNumber}}:role/worker.{{.CloudFormationTemplateID}}.eks.tmc.cloud.vmware.com"
 					tags        = { "testnptag" : "testnptagvalue", "newtesttag": "testingtagvalue"}
 					node_labels = { "testnplabelkey" : "testnplabelvalue" }
-					launch_template {
-						name = "PLACE_HOLDER"
-						version = "PLACE_HOLDER"
-					}
 					subnet_ids = [ // Required, forces new
-						"subnet-0a184f6302af32a86",
-						"subnet-0ed95d5c212ac62a1",
-						"subnet-0526ecaecde5b1bf7",
-						"subnet-06897e1063cc0cf4e",
+						"subnet-0e3bcd8e3c06a4bf0", "subnet-06427cefa730aeae7", "subnet-07c17b758e92356f6", "subnet-0a081ddc6ff1070d0"
 					]
 					scaling_config  {
 						desired_size = 4

--- a/internal/resources/testing/test_helper.go
+++ b/internal/resources/testing/test_helper.go
@@ -202,7 +202,7 @@ func TestGetDefaultEksAcceptanceConfig() *TestAcceptanceConfig {
 		AWSAccountNumber:         "919197287370",
 		Region:                   "us-west-2",
 		ClusterGroupName:         "default",
-		KubernetesVersion:        "1.26",
+		KubernetesVersion:        "1.23",
 		CredentialName:           "PLACE_HOLDER",
 		CloudFormationTemplateID: "PLACE_HOLDER",
 	}


### PR DESCRIPTION
1. **What this PR does / why we need it**:
Updated terraform to add cluster tags to the nodepool objects without complaining for any changes.
2. **Which issue(s) this PR fixes**
N/A
3. **Additional information**
As we are propagating tags from cluster to nodepool and nodepool resources. So, we added support for this as part of this PR.
**Terraform testing:**
Created cluster with nodepool
<img width="1007" alt="Screenshot 2024-01-05 at 12 15 09 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/122356562/9662bb94-50f2-422f-8037-30bf6cdfbeaf">

Applied same file without any change
<img width="900" alt="Screenshot 2024-01-05 at 12 15 27 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/122356562/2e807be6-5f50-4080-aed1-266786bd998e">

Deleted few tags from EKS cluster
<img width="1008" alt="Screenshot 2024-01-05 at 12 15 40 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/122356562/9f549ca0-19fe-44ff-9ed7-4b746a73e73e">

Again, applied same file
<img width="919" alt="Screenshot 2024-01-05 at 12 15 52 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/122356562/5aef04b6-8996-4fba-8839-117c5a6e513f">

Deleted few tags from nodepool
<img width="996" alt="Screenshot 2024-01-05 at 12 20 39 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/122356562/2319dcc8-50bb-487e-97f0-8a66fb344eda">


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
