### PR TITLE
 Fix the NPE issue in provisioner resource/datasource

### DIFF
--- a/internal/resources/provisioner/data_source_provisioner.go
+++ b/internal/resources/provisioner/data_source_provisioner.go
@@ -62,6 +62,8 @@ func dataSourceProvisionerRead(ctx context.Context, d *schema.ResourceData, m in
 				_ = schema.RemoveFromState(d, m)
 				return
 			}
+
+			return
 		}
 
 		for i := range resp.Provisioners {
@@ -78,6 +80,7 @@ func dataSourceProvisionerRead(ctx context.Context, d *schema.ResourceData, m in
 				_ = schema.RemoveFromState(d, m)
 				return
 			}
+			return
 		}
 
 		d.SetId(resp.Provisioner.Meta.UID)

--- a/internal/resources/provisioner/resource_provisioner.go
+++ b/internal/resources/provisioner/resource_provisioner.go
@@ -147,6 +147,8 @@ func resourceProvisionerRead(ctx context.Context, d *schema.ResourceData, m inte
 			_ = schema.RemoveFromState(d, m)
 			return
 		}
+
+		return
 	}
 
 	d.SetId(resp.Provisioner.Meta.UID)


### PR DESCRIPTION
1. **What this PR does / why we need it**:
   Added the fix to return without trying to parse the nil response in case of any error.

2. **Which issue(s) this PR fixes**
      Internal Jira

3. **Additional information**


4. **Special notes for your reviewer**
<img width="176" alt="Screenshot 2024-01-19 at 12 10 31 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/80737804/5dbab04f-84bb-401f-88ea-945fadc81fce">

```
<testsuite name="github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/provisioner" tests="2" failures="0" errors="0" id="230" hostname="sc2-10-187-102-46.nimbus.eng.vmware.com" time="45.050" timestamp="2024-01-19T07:26:16Z">
		<properties>
			<property name="coverage.statements.pct" value="62.80"></property>
		</properties>
		<testcase name="TestAcceptanceForProvisionerDataSource" classname="github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/provisioner" time="15.960">
			<system-out><![CDATA[    provisioner_data_source_test.go:43: provisioner datasource acceptance test complete!]]></system-out>
		</testcase>
		<testcase name="TestAcceptanceForProvisionerResource" classname="github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/provisioner" time="29.080">
			<system-out><![CDATA[    provisioner_resource_test.go:86: provisioner resource acceptance test complete!]]></system-out>
		</testcase>
	</testsuite>
```