### PR TITLE
Add  tanzukubernetescluster tag to clusterclass datasource tests 

### DIFF
--- a/internal/resources/clusterclass/tests/cluster_class_test.go
+++ b/internal/resources/clusterclass/tests/cluster_class_test.go
@@ -1,5 +1,5 @@
-//go:build clusterclass
-// +build clusterclass
+//go:build clusterclass || tanzukubernetescluster
+// +build clusterclass tanzukubernetescluster
 
 /*
 Copyright © 2023 VMware, Inc. All Rights Reserved.

--- a/internal/resources/clusterclass/tests/helper_test.go
+++ b/internal/resources/clusterclass/tests/helper_test.go
@@ -1,5 +1,5 @@
-//go:build clusterclass
-// +build clusterclass
+//go:build clusterclass || tanzukubernetescluster
+// +build clusterclass tanzukubernetescluster
 
 /*
 Copyright © 2023 VMware, Inc. All Rights Reserved.


### PR DESCRIPTION

1. **What this PR does / why we need it**:
    Add  `tanzukubernetescluster` tag to clusterclass datasource tests  to ensure that these tests are triggered while we run the tanzukubernetescluster tests in automation as both of them share the same environment requirements.

3. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->