### PR TITLE
Implement fix for failing AKS acceptance/mock test

### DIFF
--- a/internal/resources/akscluster/resource_akscluster_acc_test.go
+++ b/internal/resources/akscluster/resource_akscluster_acc_test.go
@@ -402,6 +402,9 @@ func testAKSCluster(fn *aksmodel.VmwareTanzuManageV1alpha1AksclusterFullName) st
         enable_disk_csi_driver = false
         enable_file_csi_driver = false
       }
+      identity_config {
+        type = "IDENTITY_TYPE_SYSTEM_ASSIGNED"
+      }
     }
     nodepool {
       name = "systemnp"
@@ -433,6 +436,9 @@ func testAKSClusterEnableCSI(fn *aksmodel.VmwareTanzuManageV1alpha1AksclusterFul
         enable_disk_csi_driver = true
         enable_file_csi_driver = true
       } 
+      identity_config {
+        type = "IDENTITY_TYPE_SYSTEM_ASSIGNED"
+      }
     }
     nodepool {
       name = "systemnp"
@@ -464,6 +470,9 @@ func testAKSClusterAddUserNodepool(fn *aksmodel.VmwareTanzuManageV1alpha1Aksclus
         enable_disk_csi_driver = true
         enable_file_csi_driver = true
       } 
+      identity_config {
+        type = "IDENTITY_TYPE_SYSTEM_ASSIGNED"
+      }
     }
     nodepool {
       name = "systemnp"
@@ -507,6 +516,9 @@ func mockCluster(w ...clusterWither) *aksmodel.VmwareTanzuManageV1alpha1AksClust
 				StorageConfig: &aksmodel.VmwareTanzuManageV1alpha1AksclusterStorageConfig{
 					EnableDiskCsiDriver: false,
 					EnableFileCsiDriver: false,
+				},
+				IdentityConfig: &aksmodel.VmwareTanzuManageV1alpha1AksclusterManagedIdentityConfig{
+					Type: aksmodel.VmwareTanzuManageV1alpha1AksclusterManagedIdentityTypeSYSTEMASSIGNED.Pointer(),
 				},
 				Version: "1.26.6",
 			},


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Fixes an AKS acceptance/mock test that was broken when managed identity work was introduced.

2. **Which issue(s) this PR fixes**

As described above, the 'TestAccAksCluster_basics' test was broken by the introduction of supporting managed identities for AKS clusters. This MR fixes said failing test.

3. **Additional information**

Tested both against a mock and real stack (by setting 'ENABLE_AKS_ENV_TEST' env variable).

4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->
