### PR TITLE
Update the doc link and add the example link to the cutom policy guide

### DIFF
--- a/docs/guides/tanzu-mission-control_policy.md
+++ b/docs/guides/tanzu-mission-control_policy.md
@@ -211,7 +211,7 @@ resource "tanzu-mission-control_iam_policy" "namespace_scoped_iam_policy" {
 }
 ```
 
-## Custom Policy on a CLuster Group
+## Custom Policy on a Cluster Group
 
 ```terraform
 /*
@@ -278,5 +278,141 @@ resource "tanzu-mission-control_custom_policy" "cluster_group_scoped_tmc-block-r
 ## Custom Template and Custom Policy
 
 Template provides a declarative definition of a policy, which can be used to apply custom constraints on managed kubernetes resources.
-Custom policy consumes these declared custom templates to enforce specific policies. One must create the custom template before consuming it the custom policy.
+Custom policy consumes these declared custom templates to enforce specific policies. One must create the [custom template][custom-policy-template] before consuming it in the custom policy.
 Please refer to custom policy template and custom policy terraform scripts within examples.
+
+[custom-policy-template]: https://docs.vmware.com/en/VMware-Tanzu-Mission-Control/services/tanzumc-using/GUID-F147492B-04FD-4CFD-8D1F-66E36D40D49C.html
+
+## Refer the following example for creating custom policy template and assign it to custom policy
+
+```terraform
+/*
+  NOTE: Creation of custom policy depends on cluster group and custom policy template.
+*/
+
+terraform {
+  required_providers {
+    tanzu-mission-control = {
+      source = "vmware/tanzu-mission-control"
+    }
+  }
+}
+
+# Create cluster group.
+resource "tanzu-mission-control_cluster_group" "create_cluster_group" {
+  name = "tf-demo-cluster-group"
+}
+
+# Create custom policy template.
+resource "tanzu-mission-control_custom_policy_template" "sample_template" {
+  name = "tf-custom-template-test"
+
+  spec {
+    object_type   = "ConstraintTemplate"
+    template_type = "OPAGatekeeper"
+
+    data_inventory {
+      kind    = "ConfigMap"
+      group   = "admissionregistration.k8s.io"
+      version = "v1"
+    }
+
+    data_inventory {
+      kind    = "Deployment"
+      group   = "extensions"
+      version = "v1"
+    }
+
+    template_manifest = <<YAML
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: tf-custom-template-test
+  annotations:
+    description: Requires Pods to have readiness and/or liveness probes.
+spec:
+  crd:
+    spec:
+      names:
+        kind: tf-custom-template-test
+      validation:
+        openAPIV3Schema:
+          properties:
+            probes:
+              type: array
+              items:
+                type: string
+            probeTypes:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredprobes
+        probe_type_set = probe_types {
+          probe_types := {type | type := input.parameters.probeTypes[_]}
+        }
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.containers[_]
+          probe := input.parameters.probes[_]
+          probe_is_missing(container, probe)
+          msg := get_violation_message(container, input.review, probe)
+        }
+        probe_is_missing(ctr, probe) = true {
+          not ctr[probe]
+        }
+        probe_is_missing(ctr, probe) = true {
+          probe_field_empty(ctr, probe)
+        }
+        probe_field_empty(ctr, probe) = true {
+          probe_fields := {field | ctr[probe][field]}
+          diff_fields := probe_type_set - probe_fields
+          count(diff_fields) == count(probe_type_set)
+        }
+        get_violation_message(container, review, probe) = msg {
+          msg := sprintf("Container <%v> in your <%v> <%v> has no <%v>", [container.name, review.kind.kind, review.object.metadata.name, probe])
+        }
+YAML
+  }
+}
+
+
+# Cluster group scoped custom template assigned Custom Policy
+resource "tanzu-mission-control_custom_policy" "cluster_group_scoped_custom_template_assigned_custom_policy" {
+  name = "tf-custom-template-policy-test"
+
+  scope {
+    cluster_group {
+      cluster_group = tanzu-mission-control_cluster_group.create_cluster_group.name
+    }
+  }
+
+  spec {
+    input {
+      custom {
+        template_name = tanzu-mission-control_custom_policy_template.sample_template.name
+        audit = false
+
+        target_kubernetes_resources {
+          api_groups = [
+            "apps",
+          ]
+          kinds = [
+            "Deployment"
+          ]
+        }
+
+        target_kubernetes_resources {
+          api_groups = [
+            "apps",
+          ]
+          kinds = [
+            "StatefulSet",
+          ]
+        }
+      }
+    }
+  }
+}
+```

--- a/examples/usecases/custom_policy_with_custom_template_usecase.tf
+++ b/examples/usecases/custom_policy_with_custom_template_usecase.tf
@@ -1,0 +1,129 @@
+/*
+  NOTE: Creation of custom policy depends on cluster group and custom policy template.
+*/
+
+terraform {
+  required_providers {
+    tanzu-mission-control = {
+      source = "vmware/tanzu-mission-control"
+    }
+  }
+}
+
+# Create cluster group.
+resource "tanzu-mission-control_cluster_group" "create_cluster_group" {
+  name = "tf-demo-cluster-group"
+}
+
+# Create custom policy template.
+resource "tanzu-mission-control_custom_policy_template" "sample_template" {
+  name = "tf-custom-template-test"
+
+  spec {
+    object_type   = "ConstraintTemplate"
+    template_type = "OPAGatekeeper"
+
+    data_inventory {
+      kind    = "ConfigMap"
+      group   = "admissionregistration.k8s.io"
+      version = "v1"
+    }
+
+    data_inventory {
+      kind    = "Deployment"
+      group   = "extensions"
+      version = "v1"
+    }
+
+    template_manifest = <<YAML
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: tf-custom-template-test
+  annotations:
+    description: Requires Pods to have readiness and/or liveness probes.
+spec:
+  crd:
+    spec:
+      names:
+        kind: tf-custom-template-test
+      validation:
+        openAPIV3Schema:
+          properties:
+            probes:
+              type: array
+              items:
+                type: string
+            probeTypes:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredprobes
+        probe_type_set = probe_types {
+          probe_types := {type | type := input.parameters.probeTypes[_]}
+        }
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.containers[_]
+          probe := input.parameters.probes[_]
+          probe_is_missing(container, probe)
+          msg := get_violation_message(container, input.review, probe)
+        }
+        probe_is_missing(ctr, probe) = true {
+          not ctr[probe]
+        }
+        probe_is_missing(ctr, probe) = true {
+          probe_field_empty(ctr, probe)
+        }
+        probe_field_empty(ctr, probe) = true {
+          probe_fields := {field | ctr[probe][field]}
+          diff_fields := probe_type_set - probe_fields
+          count(diff_fields) == count(probe_type_set)
+        }
+        get_violation_message(container, review, probe) = msg {
+          msg := sprintf("Container <%v> in your <%v> <%v> has no <%v>", [container.name, review.kind.kind, review.object.metadata.name, probe])
+        }
+YAML
+  }
+}
+
+
+# Cluster group scoped custom template assigned Custom Policy
+resource "tanzu-mission-control_custom_policy" "cluster_group_scoped_custom_template_assigned_custom_policy" {
+  name = "tf-custom-template-policy-test"
+
+  scope {
+    cluster_group {
+      cluster_group = tanzu-mission-control_cluster_group.create_cluster_group.name
+    }
+  }
+
+  spec {
+    input {
+      custom {
+        template_name = tanzu-mission-control_custom_policy_template.sample_template.name
+        audit = false
+
+        target_kubernetes_resources {
+          api_groups = [
+            "apps",
+          ]
+          kinds = [
+            "Deployment"
+          ]
+        }
+
+        target_kubernetes_resources {
+          api_groups = [
+            "apps",
+          ]
+          kinds = [
+            "StatefulSet",
+          ]
+        }
+      }
+    }
+  }
+}

--- a/templates/guides/tanzu-mission-control_policy.md.tmpl
+++ b/templates/guides/tanzu-mission-control_policy.md.tmpl
@@ -37,12 +37,18 @@ In the following example, there are multiple dependencies shown.
 
 {{ tffile "examples/usecases/access_policy_usecase.tf" }}
 
-## Custom Policy on a CLuster Group
+## Custom Policy on a Cluster Group
 
 {{ tffile "examples/usecases/custom_policy_usecase.tf" }}
 
 ## Custom Template and Custom Policy
 
 Template provides a declarative definition of a policy, which can be used to apply custom constraints on managed kubernetes resources.
-Custom policy consumes these declared custom templates to enforce specific policies. One must create the custom template before consuming it the custom policy.
+Custom policy consumes these declared custom templates to enforce specific policies. One must create the [custom template][custom-policy-template] before consuming it in the custom policy.
 Please refer to custom policy template and custom policy terraform scripts within examples.
+
+[custom-policy-template]: https://docs.vmware.com/en/VMware-Tanzu-Mission-Control/services/tanzumc-using/GUID-F147492B-04FD-4CFD-8D1F-66E36D40D49C.html
+
+## Refer the following example for creating custom policy template and assign it to custom policy
+
+{{ tffile "examples/usecases/custom_policy_with_custom_template_usecase.tf" }}


### PR DESCRIPTION
1. **What this PR does / why we need it**:
   Initially this check was added as the custom template creation via TMC TF provider was not supported. Now since the provider supports creation of the custom template removing this check,
    to let user create the custom template and assign it to custom policy on the fly.

2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->
![Screenshot 2024-02-12 at 4 40 01 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/80737804/2ece2613-8175-41da-92cf-7b34472ea239)

![Screenshot 2024-02-12 at 4 39 38 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/80737804/7d359bd4-4ba9-40be-b5dc-5f564a2f3883)

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->