### PR TITLE
Make meta data converter mapping generic and populate provisioner meta info

### DIFF
--- a/internal/resources/common/objectmeta_schema.go
+++ b/internal/resources/common/objectmeta_schema.go
@@ -171,17 +171,17 @@ func GetTypeIntMapData(data map[string]interface{}) map[string]int {
 }
 
 // GetMetaConverterMap returns mapping for converter.
-func GetMetaConverterMap(modelPathSeparator string) *converter.BlockToStruct {
+func GetMetaConverterMap(modelPathSeparator string, modelPath ...string) *converter.BlockToStruct {
 	var MetaConverterMap = &converter.BlockToStruct{
 		AnnotationsKey: &converter.Map{
-			converter.AllMapKeysFieldMarker: converter.BuildModelPath(modelPathSeparator, "meta", "annotations", converter.AllMapKeysFieldMarker),
+			converter.AllMapKeysFieldMarker: converter.BuildModelPath(modelPathSeparator, append(modelPath, "meta", "annotations", converter.AllMapKeysFieldMarker)...),
 		},
 		LabelsKey: &converter.Map{
-			converter.AllMapKeysFieldMarker: converter.BuildModelPath(modelPathSeparator, "meta", "labels", converter.AllMapKeysFieldMarker),
+			converter.AllMapKeysFieldMarker: converter.BuildModelPath(modelPathSeparator, append(modelPath, "meta", "labels", converter.AllMapKeysFieldMarker)...),
 		},
-		DescriptionKey:     converter.BuildModelPath(modelPathSeparator, "meta", "description"),
-		resourceVersionKey: converter.BuildModelPath(modelPathSeparator, "meta", "resourceVersion"),
-		uidKey:             converter.BuildModelPath(modelPathSeparator, "meta", "uid"),
+		DescriptionKey:     converter.BuildModelPath(modelPathSeparator, append(modelPath, "meta", "description")...),
+		resourceVersionKey: converter.BuildModelPath(modelPathSeparator, append(modelPath, "meta", "resourceVersion")...),
+		uidKey:             converter.BuildModelPath(modelPathSeparator, append(modelPath, "meta", "uid")...),
 	}
 
 	return MetaConverterMap

--- a/internal/resources/provisioner/converter_mapping.go
+++ b/internal/resources/provisioner/converter_mapping.go
@@ -24,7 +24,7 @@ var tfDataModelMap = &tfModelConverterHelper.BlockToStruct{
 		{
 			managementClusterNameKey: tfModelConverterHelper.BuildDefaultModelPath(provisionerArrayField, "fullName", "managementClusterName"),
 			nameKey:                  tfModelConverterHelper.BuildDefaultModelPath(provisionerArrayField, "fullName", "name"),
-			common.MetaKey:           common.GetMetaConverterMap(tfModelConverterHelper.DefaultModelPathSeparator),
+			common.MetaKey:           common.GetMetaConverterMap(tfModelConverterHelper.DefaultModelPathSeparator, provisionerArrayField),
 		},
 	},
 }

--- a/internal/resources/provisioner/provisioner_data_source_test.go
+++ b/internal/resources/provisioner/provisioner_data_source_test.go
@@ -67,8 +67,7 @@ func checkDataSourceAttributes(dataSourceName, resourceName string) resource.Tes
 		resource.TestCheckResourceAttrSet(dataSourceName, "id"),
 	}
 
-	// TODO: Add the meta check after TMC-54016 fix.
-	// check = append(check, metaDataSourceAttributeCheck(dataSourceName, resourceName)...)
+	check = append(check, metaDataSourceAttributeCheck(dataSourceName, resourceName)...)
 
 	return resource.ComposeTestCheckFunc(check...)
 }
@@ -84,12 +83,11 @@ func verifyProvisionerDataSource(name string) resource.TestCheckFunc {
 	}
 }
 
-// TODO: Add the meta check after TMC-54016 fix.
-// func metaDataSourceAttributeCheck(dataSourceName, resourceName string) []resource.TestCheckFunc {
-//	return []resource.TestCheckFunc{
-//		resource.TestCheckResourceAttrPair(dataSourceName, "meta.0.description", resourceName, "meta.0.description"),
-//		resource.TestCheckResourceAttrPair(dataSourceName, "meta.0.labels.key1", resourceName, "meta.0.labels.key1"),
-//		resource.TestCheckResourceAttrPair(dataSourceName, "meta.0.labels.key2", resourceName, "meta.0.labels.key2"),
-//		resource.TestCheckResourceAttrSet(dataSourceName, "meta.0.uid"),
-//	}
-//}
+func metaDataSourceAttributeCheck(dataSourceName, resourceName string) []resource.TestCheckFunc {
+	return []resource.TestCheckFunc{
+		resource.TestCheckResourceAttrPair(dataSourceName, "provisioners.0.meta.0.description", resourceName, "meta.0.description"),
+		resource.TestCheckResourceAttrPair(dataSourceName, "provisioners.0.meta.0.labels.key1", resourceName, "meta.0.labels.key1"),
+		resource.TestCheckResourceAttrPair(dataSourceName, "provisioners.0.meta.0.labels.key2", resourceName, "meta.0.labels.key2"),
+		resource.TestCheckResourceAttrSet(dataSourceName, "provisioners.0.meta.0.uid"),
+	}
+}


### PR DESCRIPTION
1. **What this PR does / why we need it**: 

Make meta data converter mapping generic and populate provisioner meta info

Meta converter was not supporting the array format as that of a provisioner resource. As a result, meta was not getting populated for provisioner because the model path was not including the entire path. In Provisioner resource scenario the meta should be `provisioner.meta`.

Made changes to accomodate this change not just for provisioner but any resource that follows this structure

3. **Which issue(s) this PR fixes**

`
{
  "version": 4,
  "terraform_version": "1.6.4",
  "serial": 1,
  "lineage": "2dcd02f2-3dcc-d8a3-42b1-f05b03f9e9fe",
  "outputs": {},
  "resources": [
    {
      "mode": "data",
      "type": "tanzu-mission-control_provisioner",
      "name": "read_provisioner",
      "provider": "provider[\"vmware/devd/tanzu-mission-control\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "id": "prvn:01HQ2DV4SAY0C5G832WHZ4TBST",
            "provisioners": [
              {
                "management_cluster": "eks",
                "meta": [
                  {
                    "annotations": {},
                    "description": "Create provisioner through terraform",
                    "labels": {
                      "key1": "value1",
                      "key2": "value2"
                    },
                    "resource_version": "4965",
                    "uid": "prvn:01HQ2DV4SAY0C5G832WHZ4TBST"
                  }
                ],
                "name": "mshobha-test",
                "org_id": ""
              }
            ]
          },
          "sensitive_attributes": []
        }
      ]
    }
  ],
  "check_results": null
}`

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


4. **Additional information**


5. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->