### PR TITLE
Fix the namespace acceptance tests

### DIFF
--- a/internal/resources/namespace/data_source_namespace_test.go
+++ b/internal/resources/namespace/data_source_namespace_test.go
@@ -38,8 +38,8 @@ func TestAcceptanceForNamespaceDataSource(t *testing.T) {
 	resourceName := fmt.Sprintf("%s.%s", namespaceResource, namespaceResourceVar)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          testPreCheck(t),
-		ProviderFactories: getTestProviderFactories(provider),
+		PreCheck:          testhelper.TestPreCheck(t),
+		ProviderFactories: testhelper.GetTestProviderFactories(provider),
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/namespace/namespace_provider_test.go
+++ b/internal/resources/namespace/namespace_provider_test.go
@@ -6,7 +6,6 @@ SPDX-License-Identifier: MPL-2.0
 package namespace
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,8 +14,6 @@ import (
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
 	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/cluster"
 )
-
-const providerName = "tmc"
 
 func initTestProvider(t *testing.T) *schema.Provider {
 	testProvider := &schema.Provider{
@@ -36,19 +33,4 @@ func initTestProvider(t *testing.T) *schema.Provider {
 	}
 
 	return testProvider
-}
-
-func testPreCheck(t *testing.T) func() {
-	return func() {
-		for _, env := range []string{authctx.ServerEndpointEnvVar, authctx.VMWCloudAPITokenEnvVar, authctx.VMWCloudEndpointEnvVar} {
-			require.NotEmpty(t, os.Getenv(env))
-		}
-	}
-}
-
-func getTestProviderFactories(provider *schema.Provider) map[string]func() (*schema.Provider, error) {
-	//nolint:unparam
-	return map[string]func() (*schema.Provider, error){
-		providerName: func() (*schema.Provider, error) { return provider, nil },
-	}
 }

--- a/internal/resources/namespace/resource_namepace_test.go
+++ b/internal/resources/namespace/resource_namepace_test.go
@@ -33,8 +33,8 @@ func TestAcceptanceForNamespaceResource(t *testing.T) {
 	clusterName := acctest.RandomWithPrefix("tf-cluster")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          testPreCheck(t),
-		ProviderFactories: getTestProviderFactories(provider),
+		PreCheck:          testhelper.TestPreCheck(t),
+		ProviderFactories: testhelper.GetTestProviderFactories(provider),
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
Provider configuration has the wrong provider name as "tmc" instead of "tanzu-mission-control" causing the tests to fail. Modified the test to use the common provider testing code instead of the incorrect one.

1. **What this PR does / why we need it**:
     Fixes the failing namespace acceptance tests
2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes issue tracked in internal Jira


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->
   ```
 namespace % go test -v -tags=namespace                                     
=== RUN   TestAcceptanceForNamespaceDataSource
TMC resources applied to the cluster successfully
    data_source_namespace_test.go:53: namespace data source acceptance test complete!
--- PASS: TestAcceptanceForNamespaceDataSource (301.15s)
.......
   TMC resources applied to the cluster successfully
    resource_namepace_test.go:49: namespace resource acceptance test complete!
--- PASS: TestAcceptanceForNamespaceResource (279.15s)
```

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->