### PR TITLE
Fixed eks acceptance testing related issue

### DIFF
--- a/internal/resources/ekscluster/resource_ekscluster_test.go
+++ b/internal/resources/ekscluster/resource_ekscluster_test.go
@@ -312,9 +312,10 @@ func TestAcceptanceForMkpClusterResource(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      testhelper.EksClusterResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            testhelper.EksClusterResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{waitForKubeconfig},
 			},
 		},
 	})
@@ -418,7 +419,7 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 	return eksmodel.VmwareTanzuManageV1alpha1EksclusterSpec{
 			ClusterGroupName: "default",
 			Config: &eksmodel.VmwareTanzuManageV1alpha1EksclusterControlPlaneConfig{
-				Version: "1.23",
+				Version: "1.26",
 				RoleArn: controlPlaneRoleARN,
 				Tags: map[string]string{
 					"tmc.cloud.vmware.com/tmc-managed": "true",
@@ -441,14 +442,9 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 					PublicAccessCidrs: []string{
 						"0.0.0.0/0",
 					},
-					SecurityGroups: []string{
-						"sg-0a6768722e9716768",
-					},
+					SecurityGroups: []string{"sg-0b77767aa25e20fec"},
 					SubnetIds: []string{
-						"subnet-0a184f6302af32a86",
-						"subnet-0ed95d5c212ac62a1",
-						"subnet-0526ecaecde5b1bf7",
-						"subnet-06897e1063cc0cf4e",
+						"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9",
 					},
 				},
 			},
@@ -460,12 +456,9 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 					Description: "tf nodepool description",
 				},
 				Spec: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolSpec{
-					RoleArn: workerRoleArn,
-					AmiType: "CUSTOM",
-					AmiInfo: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolAmiInfo{
-						AmiID:                "ami-2qu8409oisdfj0qw",
-						OverrideBootstrapCmd: "#!/bin/bash\n/etc/eks/bootstrap.sh tf-test-ami",
-					},
+					RoleArn:      workerRoleArn,
+					AmiType:      "AL2_x86_64",
+					AmiInfo:      &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolAmiInfo{},
 					CapacityType: "ON_DEMAND",
 					RootDiskSize: 40,
 					Tags: map[string]string{
@@ -477,16 +470,7 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 						"testnplabelkey": "testnplabelvalue",
 					},
 					SubnetIds: []string{
-						"subnet-0a184f6302af32a86",
-						"subnet-0ed95d5c212ac62a1",
-						"subnet-0526ecaecde5b1bf7",
-						"subnet-06897e1063cc0cf4e",
-					},
-					RemoteAccess: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolRemoteAccess{
-						SSHKey: "anshulc",
-						SecurityGroups: []string{
-							"sg-0a6768722e9716768",
-						},
+						"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9",
 					},
 					ScalingConfig: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolScalingConfig{
 						DesiredSize: 4,
@@ -501,6 +485,7 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 						"m3.large",
 					},
 					Taints:         make([]*eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolTaint, 0),
+					RemoteAccess:   &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolRemoteAccess{},
 					LaunchTemplate: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolLaunchTemplate{},
 				},
 			},
@@ -520,15 +505,9 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 						"testnplabelkey": "testnplabelvalue",
 					},
 					SubnetIds: []string{
-						"subnet-0a184f6302af32a86",
-						"subnet-0ed95d5c212ac62a1",
-						"subnet-0526ecaecde5b1bf7",
-						"subnet-06897e1063cc0cf4e",
+						"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9",
 					},
-					LaunchTemplate: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolLaunchTemplate{
-						Name:    "PLACE_HOLDER",
-						Version: "PLACE_HOLDER",
-					},
+					LaunchTemplate: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolLaunchTemplate{},
 					ScalingConfig: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolScalingConfig{
 						DesiredSize: 4,
 						MaxSize:     8,

--- a/internal/resources/testing/test_config.go
+++ b/internal/resources/testing/test_config.go
@@ -36,10 +36,10 @@ const testDefaultCreateEksClusterScript = `
 					  "0.0.0.0/0",
 					]
 					security_groups = [ // Forces new
-					  "sg-09247a89b01962bd9",
+					  "sg-0b77767aa25e20fec",
 					]
 					subnet_ids = [ // Forces new
-					  	"subnet-0e3bcd8e3c06a4bf0", "subnet-06427cefa730aeae7", "subnet-07c17b758e92356f6", "subnet-0a081ddc6ff1070d0"
+					  	"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9"
 					]
 				}
 			}
@@ -58,7 +58,7 @@ const testDefaultCreateEksClusterScript = `
 					tags           = { "testnptag" : "testnptagvalue", "newtesttag": "testingtagvalue"}
 					node_labels    = { "testnplabelkey" : "testnplabelvalue" }
 					subnet_ids = [ // Required, forces new
-						"subnet-0e3bcd8e3c06a4bf0", "subnet-06427cefa730aeae7", "subnet-07c17b758e92356f6", "subnet-0a081ddc6ff1070d0"
+						"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9"
 					]
 					scaling_config  {
 						desired_size = 4
@@ -86,7 +86,7 @@ const testDefaultCreateEksClusterScript = `
 					tags        = { "testnptag" : "testnptagvalue", "newtesttag": "testingtagvalue"}
 					node_labels = { "testnplabelkey" : "testnplabelvalue" }
 					subnet_ids = [ // Required, forces new
-						"subnet-0e3bcd8e3c06a4bf0", "subnet-06427cefa730aeae7", "subnet-07c17b758e92356f6", "subnet-0a081ddc6ff1070d0"
+						"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9"
 					]
 					scaling_config  {
 						desired_size = 4

--- a/internal/resources/testing/test_helper.go
+++ b/internal/resources/testing/test_helper.go
@@ -202,7 +202,7 @@ func TestGetDefaultEksAcceptanceConfig() *TestAcceptanceConfig {
 		AWSAccountNumber:         "919197287370",
 		Region:                   "us-west-2",
 		ClusterGroupName:         "default",
-		KubernetesVersion:        "1.23",
+		KubernetesVersion:        "1.26",
 		CredentialName:           "PLACE_HOLDER",
 		CloudFormationTemplateID: "PLACE_HOLDER",
 	}


### PR DESCRIPTION
1. **What this PR does / why we need it**:
As part of this, we have fixed issue related to acceptance EKS testing.
2. **Which issue(s) this PR fixes**
N/A
3. **Additional information**
In the terraform automation the ekscluster acceptance tests started failing again , looks like it is due to some recent change to the resource.
Below the error snippet:

<testcase name="TestFlattenNodepoolSpec/sg_in_remote_access_is_nil" classname="github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/ekscluster" time="0.000"></testcase> <testcase name="TestAcceptanceForMkpClusterResource" classname="github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/ekscluster" time="4.390"> <failure message="Failed"><![CDATA[ resource_ekscluster_test.go:303: Step 1/2 error: Error running apply: exit status 1 Error: Unable to create Tanzu Mission Control EKS cluster entry, name : terraform-eks-test: POST request failed with status : 400 Bad Request, response: {"error":"validating the inputs failed: failed to validate cluster vpc config: invalid option: rpc error: code = Internal desc = subnet-0e3bcd8e3c06a4bf0, subnet-06427cefa730aeae7, subnet-07c17b758e92356f6, subnet-0a081ddc6ff1070d0 should be present in available VPCs for region us-west-2","code":3,"message":"validating the inputs failed: failed to validate cluster vpc config: invalid option: rpc error: code = Internal desc = subnet-0e3bcd8e3c06a4bf0, subnet-06427cefa730aeae7, subnet-07c17b758e92356f6, subnet-0a081ddc6ff1070d0 should be present in available VPCs for region us-west-2"} with tanzu-mission-control_ekscluster.test_create_eks_cluster, on terraform_plugin_test.tf line 2, in resource "tanzu-mission-control_ekscluster" "test_create_eks_cluster": 2: resource tanzu-mission-control_ekscluster test_create_eks_cluster { ]]></failure> </testcase> </testsuite>

4. **Special notes for your reviewer**
