### PR TITLE
Refresh auth context while polling for data protection resources

### DIFF
--- a/internal/resources/backupschedule/resource_backup_schedule.go
+++ b/internal/resources/backupschedule/resource_backup_schedule.go
@@ -463,6 +463,11 @@ func readResourceWait(ctx context.Context, config *authctx.TanzuContext, resourc
 		resp, err = config.TMCConnection.BackupScheduleService.BackupScheduleResourceServiceGet(resourceFullName)
 
 		if err != nil || resp == nil || resp.Schedule == nil {
+			if clienterrors.IsUnauthorizedError(err) {
+				authctx.RefreshUserAuthContext(config, clienterrors.IsUnauthorizedError, err)
+				continue
+			}
+
 			return nil, err
 		}
 

--- a/internal/resources/targetlocation/resource_target_location.go
+++ b/internal/resources/targetlocation/resource_target_location.go
@@ -266,6 +266,11 @@ func readResourceWait(ctx context.Context, config *authctx.TanzuContext, resourc
 		resp, err = config.TMCConnection.TargetLocationService.TargetLocationResourceServiceGet(resourceFullName)
 
 		if err != nil || resp == nil || resp.BackupLocation == nil {
+			if clienterrors.IsUnauthorizedError(err) {
+				authctx.RefreshUserAuthContext(config, clienterrors.IsUnauthorizedError, err)
+				continue
+			}
+
 			return nil, err
 		}
 


### PR DESCRIPTION
1. **What this PR does / why we need it**:

The data protection related resources have a poll stage where post-creation they wait to reach a terminating state. In Self Managed environments, the auth token may expire during this process. This PR adds refresh logic.

Manually tested the fix.

Acceptance tests passed:

<img width="1000" alt="Screenshot 2024-03-22 at 8 26 52 PM" src="https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/53172692/a709c91f-4eb5-4791-aaf9-2fa59d4d4742">


2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->