### PR TITLE
Update headers by invoking RefreshAuthCtx even for get and delete operation in terraform

### DIFF
--- a/internal/client/transport/methods.go
+++ b/internal/client/transport/methods.go
@@ -105,7 +105,18 @@ func (c *Client) invokeAction(httpMethodType string, url string, request Request
 func (c *Client) Delete(url string) error {
 	requestURL := fmt.Sprintf("%s/%s", c.Host, strings.TrimPrefix(url, "/"))
 
-	resp, err := c.delete(requestURL, c.Headers)
+	headers := c.Headers.Clone()
+
+	md, err := c.RefreshAuthCtx()
+	if err != nil {
+		return errors.Wrap(err, "error while setting auth headers")
+	}
+
+	for key, value := range md {
+		headers.Set(key, value)
+	}
+
+	resp, err := c.delete(requestURL, headers)
 	if err != nil {
 		return errors.Wrap(err, "delete")
 	}
@@ -126,7 +137,18 @@ func (c *Client) Delete(url string) error {
 func (c *Client) Get(url string, response Response) error {
 	requestURL := fmt.Sprintf("%s/%s", c.Host, strings.TrimPrefix(url, "/"))
 
-	resp, err := c.get(requestURL, c.Headers)
+	headers := c.Headers.Clone()
+
+	md, err := c.RefreshAuthCtx()
+	if err != nil {
+		return errors.Wrap(err, "error while setting auth headers")
+	}
+
+	for key, value := range md {
+		headers.Set(key, value)
+	}
+
+	resp, err := c.get(requestURL, headers)
 	if err != nil {
 		return errors.Wrap(err, "get request")
 	}


### PR DESCRIPTION
This resolves the token expiry issue in SM env for get and delete operations in batch operations which spans beyond token expiry

1. **What this PR does / why we need it**:
       In TMC SM the auth token is short lived. Hence for every API call a new token should be used. Current implementation handles this case for POST/PUT/PATCH but not for DELETE/GET causing these operations to fail with 401 error if they are triggered after the token expiry in a batch terraform apply. 

Hence added the fix to refresh the token for all operations for SM environment. 
2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes # The 401 error in TMC SM terraform  e2e testing automation.


3. **Additional information**


4. **Special notes for your reviewer**

manual validation done for couple of runs in e2e automation and the issue is not surfaced again after the fix. So we should be good.

Sample logs:
`2024-04-15 18:33:22,529 - Plan: 9 to add, 0 to change, 0 to destroy.
2024-04-15 18:33:25,085 - module.resources.tanzu-mission-control_cluster_group.create_cluster_group[0]: Creating...
2024-04-15 18:33:25,085 - module.resources.tanzu-mission-control_workspace.create_workspace[0]: Creating...
2024-04-15 18:33:30,336 - module.resources.tanzu-mission-control_cluster_group.create_cluster_group[0]: Creation complete after 5s [id=cg:01HVHGJ8CS8RE3A2MV4NBQQ83Y]
2024-04-15 18:33:30,346 - module.resources.tanzu-mission-control_iam_policy.cluster_group_scoped_iam_policy[0]: Creating...
2024-04-15 18:33:30,349 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Creating...
2024-04-15 18:33:35,086 - module.resources.tanzu-mission-control_workspace.create_workspace[0]: Still creating... [10s elapsed]
2024-04-15 18:33:38,203 - module.resources.tanzu-mission-control_workspace.create_workspace[0]: Creation complete after 13s [id=ws:01HVHGJ8HDNEJHS80W6SWGY80F]
2024-04-15 18:33:38,214 - module.resources.tanzu-mission-control_iam_policy.workspace_scoped_iam_policy[0]: Creating...
2024-04-15 18:33:40,346 - module.resources.tanzu-mission-control_iam_policy.cluster_group_scoped_iam_policy[0]: Still creating... [10s elapsed]
2024-04-15 18:33:40,351 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [10s elapsed]
2024-04-15 18:33:45,408 - module.resources.tanzu-mission-control_iam_policy.cluster_group_scoped_iam_policy[0]: Creation complete after 15s [id=cg:01HVHGJ8CS8RE3A2MV4NBQQ83Y]
2024-04-15 18:33:48,214 - module.resources.tanzu-mission-control_iam_policy.workspace_scoped_iam_policy[0]: Still creating... [10s elapsed]
2024-04-15 18:33:48,570 - module.resources.tanzu-mission-control_iam_policy.workspace_scoped_iam_policy[0]: Creation complete after 11s [id=ws:01HVHGJ8HDNEJHS80W6SWGY80F]
2024-04-15 18:33:50,352 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [20s elapsed]
2024-04-15 18:34:00,353 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [30s elapsed]
2024-04-15 18:34:10,355 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [40s elapsed]
2024-04-15 18:34:20,356 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [50s elapsed]
2024-04-15 18:34:30,356 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [1m0s elapsed]
2024-04-15 18:34:40,357 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [1m10s elapsed]
2024-04-15 18:34:50,359 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [1m20s elapsed]
2024-04-15 18:35:00,360 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Still creating... [1m30s elapsed]
2024-04-15 18:35:02,386 - module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0]: Creation complete after 1m32s [id=c:01HVHGJFZRY82XWY5AVRR88M2Q]
2024-04-15 18:35:02,397 - module.resources.tanzu-mission-control_namespace.create_namespace[0]: Creating...
2024-04-15 18:35:02,400 - module.resources.tanzu-mission-control_iam_policy.cluster_scoped_iam_policy[0]: Creating...
2024-04-15 18:35:12,162 - module.resources.tanzu-mission-control_namespace.create_namespace[0]: Creation complete after 10s [id=ns:01HVHGN7311AW4MBGHNQ3R7SFR]
2024-04-15 18:35:12,172 - module.resources.tanzu-mission-control_iam_policy.namespace_scoped_iam_policy[0]: Creating...
2024-04-15 18:35:12,400 - module.resources.tanzu-mission-control_iam_policy.cluster_scoped_iam_policy[0]: Still creating... [10s elapsed]
2024-04-15 18:35:12,537 - module.resources.tanzu-mission-control_iam_policy.cluster_scoped_iam_policy[0]: Creation complete after 11s [id=c:01HVHGJFZRY82XWY5AVRR88M2Q]
2024-04-15 18:35:17,779 - module.resources.tanzu-mission-control_iam_policy.namespace_scoped_iam_policy[0]: Creation complete after 6s [id=ns:01HVHGN7311AW4MBGHNQ3R7SFR]
2024-04-15 18:35:17,792 - module.resources.time_sleep.wait_120_seconds: Creating...
2024-04-15 18:35:27,793 - module.resources.time_sleep.wait_120_seconds: Still creating... [10s elapsed]
2024-04-15 18:35:37,794 - module.resources.time_sleep.wait_120_seconds: Still creating... [20s elapsed]
2024-04-15 18:35:47,794 - module.resources.time_sleep.wait_120_seconds: Still creating... [30s elapsed]
2024-04-15 18:35:57,795 - module.resources.time_sleep.wait_120_seconds: Still creating... [40s elapsed]
2024-04-15 18:36:07,795 - module.resources.time_sleep.wait_120_seconds: Still creating... [50s elapsed]
2024-04-15 18:36:17,796 - module.resources.time_sleep.wait_120_seconds: Still creating... [1m0s elapsed]
2024-04-15 18:36:27,797 - module.resources.time_sleep.wait_120_seconds: Still creating... [1m10s elapsed]
2024-04-15 18:36:37,797 - module.resources.time_sleep.wait_120_seconds: Still creating... [1m20s elapsed]
2024-04-15 18:36:47,798 - module.resources.time_sleep.wait_120_seconds: Still creating... [1m30s elapsed]
2024-04-15 18:36:57,798 - module.resources.time_sleep.wait_120_seconds: Still creating... [1m40s elapsed]
2024-04-15 18:37:07,799 - module.resources.time_sleep.wait_120_seconds: Still creating... [1m50s elapsed]
2024-04-15 18:37:17,796 - module.resources.time_sleep.wait_120_seconds: Creation complete after 2m0s [id=2024-04-15T18:37:17Z]
2024-04-15 18:37:17,806 - ╷
2024-04-15 18:37:17,806 - │ Warning: Kubernetes cluster's kubeconfig provided. Proceeding to attach the cluster TMC
2024-04-15 18:37:17,806 - │ 
2024-04-15 18:37:17,806 - │   with module.resources.tanzu-mission-control_cluster.attach_cluster_with_kubeconfig_path[0],
2024-04-15 18:37:17,806 - │   on resources/cluster.tf line 14, in resource "tanzu-mission-control_cluster" "attach_cluster_with_kubeconfig_path":
2024-04-15 18:37:17,806 - │   14: resource "tanzu-mission-control_cluster" "attach_cluster_with_kubeconfig_path" {
2024-04-15 18:37:17,806 - │ 
2024-04-15 18:37:17,806 - ╵
2024-04-15 18:37:17,807 - 
2024-04-15 18:37:17,807 - Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
2024-04-15 18:37:17,813 - 
2024-04-15 18:37:17,813 - terraform apply is executed successfully
`