### PR TITLE
Add acceptance tests for TAP EULA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq ($(TEST_FLAGS),)
 endif
 
 ifeq ($(BUILD_TAGS),)
-	BUILD_TAGS := 'akscluster cluster clustergroup credential ekscluster gitrepository iampolicy kustomization namespace custompolicy imagepolicy networkpolicy quotapolicy securitypolicy sourcesecret workspace tanzupackage tanzupackages packagerepository packageinstall clustersecret integration mutationpolicy helmfeature helmrelease helmcharts helmrepository backupschedule targetlocation dataprotection tanzukubernetescluster clusterclass managementcluster provisioner inspections custompolicytemplate customiamrole permissiontemplate'
+	BUILD_TAGS := 'akscluster cluster clustergroup credential ekscluster gitrepository iampolicy kustomization namespace custompolicy imagepolicy networkpolicy quotapolicy securitypolicy sourcesecret workspace tanzupackage tanzupackages packagerepository packageinstall tapeula clustersecret integration mutationpolicy helmfeature helmrelease helmcharts helmrepository backupschedule targetlocation dataprotection tanzukubernetescluster clusterclass managementcluster provisioner inspections custompolicytemplate customiamrole permissiontemplate'
 endif
 
 .PHONY: build clean-up test gofmt vet lint acc-test website-lint website-lint-fix

--- a/internal/resources/tap/eula/data_source_eula.go
+++ b/internal/resources/tap/eula/data_source_eula.go
@@ -91,8 +91,15 @@ func retrieveEULADataFromServer(config authctx.TanzuContext, eula *tapeulamodel.
 		return eulaDataFromServer, err
 	}
 
-	if err := d.Set(OrgIDKey, resp.Eula.OrgID); err != nil {
-		return eulaDataFromServer, err
+	orgID, ok := d.Get(OrgIDKey).(string)
+	if !ok {
+		return eulaDataFromServer, errors.New("Unable to read organization id for EULA")
+	}
+
+	if orgID != "" {
+		if err := d.Set(OrgIDKey, resp.Eula.OrgID); err != nil {
+			return eulaDataFromServer, err
+		}
 	}
 
 	return eulaDataFromServer, nil

--- a/internal/resources/tap/eula/data_source_eula_mock_test.go
+++ b/internal/resources/tap/eula/data_source_eula_mock_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright © 2024 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package tapeula
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-test/deep"
+	"github.com/jarcoal/httpmock"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/helper"
+	tapeulamodel "github.com/vmware/terraform-provider-tanzu-mission-control/internal/models/tap/eula"
+)
+
+// nolint: unused
+const (
+	https                   = "https:/"
+	apiVersionAndGroup      = "v1alpha1/tanzupackage"
+	apiKind                 = "tap/eulas"
+	queryParamKeyOrgID      = "orgId"
+	queryParamKeyTAPVersion = "tapVersion"
+)
+
+// nolint: unused
+func getMockData() *tapeulamodel.VmwareTanzuManageV1alpha1TanzupackageTapEulaData {
+	return &tapeulamodel.VmwareTanzuManageV1alpha1TanzupackageTapEulaData{
+		Accepted:   true,
+		EulaURL:    "https://network.tanzu.vmware.com/legal_documents/vmware_general_terms",
+		ReleasedAt: strfmt.DateTime{},
+		User:       "test_uer_id",
+	}
+}
+
+// nolint: unparam, unused
+func bodyInspectingResponder(t *testing.T, expectedContent interface{}, successResponse int, successResponseBody interface{}) httpmock.Responder {
+	return func(r *http.Request) (*http.Response, error) {
+		successFunc := func() (*http.Response, error) {
+			return httpmock.NewJsonResponse(successResponse, successResponseBody)
+		}
+
+		if expectedContent == nil {
+			return successFunc()
+		}
+
+		// Compare to expected content.
+		expectedBytes, err := json.Marshal(expectedContent)
+		if err != nil {
+			t.Fail()
+			return nil, err
+		}
+
+		if r.Body == nil {
+			t.Fail()
+			return nil, fmt.Errorf("expected body on request")
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fail()
+			return nil, err
+		}
+
+		var bodyInterface map[string]interface{}
+		if err = json.Unmarshal(bodyBytes, &bodyInterface); err == nil {
+			var expectedInterface map[string]interface{}
+
+			err = json.Unmarshal(expectedBytes, &expectedInterface)
+			if err != nil {
+				return nil, err
+			}
+
+			diff := deep.Equal(bodyInterface, expectedInterface)
+			if diff == nil {
+				return successFunc()
+			}
+		} else {
+			return nil, err
+		}
+
+		return successFunc()
+	}
+}
+
+// nolint: unused
+func (testConfig *testAcceptanceConfig) setupHTTPMocks(t *testing.T) {
+	httpmock.Activate()
+	t.Cleanup(httpmock.Deactivate)
+
+	endpoint := os.Getenv("TMC_ENDPOINT")
+
+	OrgID := os.Getenv("ORG_ID")
+
+	postRequest := &tapeulamodel.VmwareTanzuManageV1alpha1TanzupackageTapEulaAcceptEulaRequest{
+		Eula: &tapeulamodel.VmwareTanzuManageV1alpha1TanzupackageTapEulaEula{
+			OrgID:      OrgID,
+			TapVersion: tapEULATAPVersion,
+		},
+	}
+
+	postResponse := &tapeulamodel.VmwareTanzuManageV1alpha1TanzupackageTapEulaAcceptEulaResponse{
+		Eula: &tapeulamodel.VmwareTanzuManageV1alpha1TanzupackageTapEulaEula{
+			OrgID:      OrgID,
+			TapVersion: tapEULATAPVersion,
+			Data:       getMockData(),
+		},
+	}
+
+	postEndpoint := helper.ConstructRequestURL(https, endpoint, apiVersionAndGroup, apiKind).String()
+
+	httpmock.RegisterResponder("POST", postEndpoint,
+		bodyInspectingResponder(t, postRequest, 200, postResponse))
+
+	getModel := &tapeulamodel.VmwareTanzuManageV1alpha1TanzupackageTapEulaEula{
+		OrgID:      OrgID,
+		TapVersion: tapEULATAPVersion,
+		Data:       getMockData(),
+	}
+
+	getResponse := &tapeulamodel.VmwareTanzuManageV1alpha1TanzupackageTapEulaValidateEulaResponse{
+		Eula: getModel,
+	}
+
+	queryParams := url.Values{}
+
+	if getModel.OrgID != "" {
+		queryParams.Add(queryParamKeyOrgID, getModel.OrgID)
+	}
+
+	if getModel.TapVersion != "" {
+		queryParams.Add(queryParamKeyTAPVersion, getModel.TapVersion)
+	}
+
+	getTAPEULAEndpoint := helper.ConstructRequestURL(https, endpoint, apiVersionAndGroup, apiKind).AppendQueryParams(queryParams).String()
+
+	httpmock.RegisterResponder("GET", getTAPEULAEndpoint,
+		bodyInspectingResponder(t, nil, 200, getResponse))
+}

--- a/internal/resources/tap/eula/data_source_eula_test.go
+++ b/internal/resources/tap/eula/data_source_eula_test.go
@@ -1,0 +1,115 @@
+//go:build tapeula
+// +build tapeula
+
+/*
+Copyright © 2024 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package tapeula
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	testhelper "github.com/vmware/terraform-provider-tanzu-mission-control/internal/resources/testing"
+)
+
+func testGetDefaultAcceptanceConfig(t *testing.T) *testAcceptanceConfig {
+	return &testAcceptanceConfig{
+		Provider:                    initTestProvider(t),
+		TAPEULAResource:             tapEULAResource,
+		TAPEULAResourceVar:          tapEULAResourceVar,
+		TAPEULAResourceTAPVersion:   fmt.Sprintf("%s.%s", tapEULAResource, tapEULAResourceVar),
+		TAPEULATAPVersion:           tapEULATAPVersion,
+		TAPEULADataSourceVar:        tapEULADataSourceVar,
+		TAPEULADataSourceTAPVersion: fmt.Sprintf("data.%s.%s", ResourceName, tapEULADataSourceVar),
+	}
+}
+
+func TestAcceptanceForTAPEULADataSource(t *testing.T) {
+	testConfig := testGetDefaultAcceptanceConfig(t)
+
+	// If the flag to execute tap eula tests is not found, run this as a mock test by setting up a http intercept for each endpoint.
+	_, found := os.LookupEnv("ENABLE_TAPEULA_ENV_TEST")
+	if !found {
+		os.Setenv("TF_ACC", "true")
+		os.Setenv("TMC_ENDPOINT", "dummy.tmc.mock.vmware.com")
+		os.Setenv("VMW_CLOUD_API_TOKEN", "dummy")
+		os.Setenv("VMW_CLOUD_ENDPOINT", "console.cloud.vmware.com")
+
+		log.Println("Setting up the mock endpoints...")
+		testConfig.setupHTTPMocks(t)
+	} else {
+		// Environment variables with non default values required for a successful call to Package Deployment Service.
+		requiredVars := []string{
+			"VMW_CLOUD_ENDPOINT",
+			"TMC_ENDPOINT",
+			"VMW_CLOUD_API_TOKEN",
+			"ORG_ID",
+		}
+
+		// Check if the required environment variables are set.
+		for _, name := range requiredVars {
+			if _, found := os.LookupEnv(name); !found {
+				t.Errorf("required environment variable '%s' missing", name)
+			}
+		}
+	}
+
+	t.Log("start tap eula data source acceptance tests!")
+
+	// Test case for tap eula data source.
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testhelper.TestPreCheck(t),
+		ProviderFactories: testhelper.GetTestProviderFactories(testConfig.Provider),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig.getTestTAPEULADataSourceBasicConfigValue(),
+				Check:  testConfig.checkTAPEULADataSourceAttributes(),
+			},
+		},
+	},
+	)
+
+	t.Log("tap eula data source acceptance test completed")
+}
+
+func (testConfig *testAcceptanceConfig) getTestTAPEULADataSourceBasicConfigValue() string {
+	return fmt.Sprintf(`
+	resource "%s" "%s" {
+	 tap_version = "%s"
+	}
+
+	data "%s" "%s" {
+		tap_version = tanzu-mission-control_tap_eula.test_tap_eula.tap_version
+	}
+	`, testConfig.TAPEULAResource, testConfig.TAPEULAResourceVar, testConfig.TAPEULATAPVersion, testConfig.TAPEULAResource, testConfig.TAPEULADataSourceVar)
+}
+
+// checkTAPEULADataSourceAttributes checks for tap eula creation attributes.
+func (testConfig *testAcceptanceConfig) checkTAPEULADataSourceAttributes() resource.TestCheckFunc {
+	var check = []resource.TestCheckFunc{
+		testConfig.verifyTAPEULADataSourceCreation(testConfig.TAPEULADataSourceTAPVersion),
+		resource.TestCheckResourceAttrPair(testConfig.TAPEULADataSourceTAPVersion, "tap_version", testConfig.TAPEULAResourceTAPVersion, "tap_version"),
+	}
+
+	return resource.ComposeTestCheckFunc(check...)
+}
+
+func (testConfig *testAcceptanceConfig) verifyTAPEULADataSourceCreation(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module does not have tap eula resource %s", name)
+		}
+
+		return nil
+	}
+}

--- a/internal/resources/tap/eula/eula_provider_test.go
+++ b/internal/resources/tap/eula/eula_provider_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright © 2024 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package tapeula
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+)
+
+// nolint: unused
+func initTestProvider(t *testing.T) *schema.Provider {
+	testProvider := &schema.Provider{
+		Schema: authctx.ProviderAuthSchema(),
+		ResourcesMap: map[string]*schema.Resource{
+			ResourceName: ResourceEULA(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			ResourceName: DataSourceEULA(),
+		},
+		ConfigureContextFunc: getConfigureContextFunc(),
+	}
+	if err := testProvider.InternalValidate(); err != nil {
+		require.NoError(t, err)
+	}
+
+	return testProvider
+}

--- a/internal/resources/tap/eula/resource_eula.go
+++ b/internal/resources/tap/eula/resource_eula.go
@@ -32,14 +32,14 @@ func ResourceEULA() *schema.Resource {
 }
 
 func getResourceSchema() map[string]*schema.Schema {
-	return getSecretSchema(false)
+	return getTAPEULASchema(false)
 }
 
 func getDataSourceSchema() map[string]*schema.Schema {
-	return getSecretSchema(true)
+	return getTAPEULASchema(true)
 }
 
-func getSecretSchema(isDataSource bool) map[string]*schema.Schema {
+func getTAPEULASchema(isDataSource bool) map[string]*schema.Schema {
 	var eulaSchema = map[string]*schema.Schema{
 		TAPVersionKey: {
 			Type:        schema.TypeString,
@@ -54,7 +54,7 @@ func getSecretSchema(isDataSource bool) map[string]*schema.Schema {
 		OrgIDKey: {
 			Type:        schema.TypeString,
 			Description: "ID of Organization.",
-			Required:    true,
+			Optional:    true,
 			ValidateFunc: validation.All(
 				validation.StringIsNotEmpty,
 				validation.StringIsNotWhiteSpace,

--- a/internal/resources/tap/eula/test_helper.go
+++ b/internal/resources/tap/eula/test_helper.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2024 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package tapeula
+
+import (
+	"context"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/vmware/terraform-provider-tanzu-mission-control/internal/authctx"
+)
+
+// nolint: gosec, unused
+const (
+	tapEULAResource      = ResourceName
+	tapEULAResourceVar   = "test_tap_eula"
+	tapEULADataSourceVar = "test_data_tap_eula"
+	tapEULATAPVersion    = "1.8.1"
+)
+
+// nolint: unused
+type testAcceptanceConfig struct {
+	Provider                    *schema.Provider
+	TAPEULAResource             string
+	TAPEULAResourceVar          string
+	TAPEULAResourceTAPVersion   string
+	TAPEULATAPVersion           string
+	TAPEULADataSourceVar        string
+	TAPEULADataSourceTAPVersion string
+}
+
+// nolint: unused
+func getConfigureContextFunc() func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	if _, found := os.LookupEnv("ENABLE_TAPEULA_ENV_TEST"); !found {
+		return authctx.ProviderConfigureContextWithDefaultTransportForTesting
+	}
+
+	return authctx.ProviderConfigureContext
+}


### PR DESCRIPTION
1. **What this PR does / why we need it**:

Add acceptance tests for TAP EULA

![Screenshot 2024-04-29 at 3 09 16 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/50652677/4de1fc16-4250-45e9-9072-68d10e65c6f2)

Mock

![Screenshot 2024-04-29 at 3 11 20 PM](https://github.com/vmware/terraform-provider-tanzu-mission-control/assets/50652677/19603288-03d4-4525-87ce-b475209195a0)


