### PR TITLE
Mark osimage and coreaddon computed

### DIFF
--- a/internal/resources/tanzukubernetescluster/schema.go
+++ b/internal/resources/tanzukubernetescluster/schema.go
@@ -201,6 +201,7 @@ var TopologySchema = &schema.Schema{
 			CoreAddonKey: {
 				Type:        schema.TypeList,
 				Description: "(Repeatable Block) The core addons.",
+				Computed:    true,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -357,6 +358,7 @@ var OSImageSchema = &schema.Schema{
 	Type:        schema.TypeList,
 	Description: "OS image block",
 	MaxItems:    1,
+	Computed:    true,
 	Optional:    true,
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
If a cluster is create without osimage and coreaddon, default value will be filled, when the cluster is updated with the original configuration file, it prompts the difference.

1. **What this PR does / why we need it**:
  This PR is to hide the default value of osImage and coreAddons.
2. **Which issue(s) this PR fixes**

        (optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged):

        Fixes #


3. **Additional information**


4. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->