### PR TITLE
Support autoscaling

### DIFF
--- a/docs/resources/tanzu_kubernetes_cluster.md
+++ b/docs/resources/tanzu_kubernetes_cluster.md
@@ -447,6 +447,7 @@ Required:
 
 Optional:
 
+- `auto_scaling` (Block List, Max: 1) Autoscaling block (see [below for nested schema](#nestedblock--spec--topology--nodepool--spec--auto_scaling))
 - `failure_domain` (String) The failure domain the machines will be created in.
 - `meta` (Block List, Max: 1) Metadata for the resource (see [below for nested schema](#nestedblock--spec--topology--nodepool--spec--meta))
 - `os_image` (Block List, Max: 1) OS image block (see [below for nested schema](#nestedblock--spec--topology--nodepool--spec--os_image))
@@ -469,6 +470,16 @@ Required:
 - `arch` (String) The architecture of the OS image.
 - `name` (String) The name of the OS image.
 - `version` (String) The version of the OS image.
+
+
+<a id="nestedblock--spec--topology--nodepool--spec--auto_scaling"></a>
+### Nested Schema for `spec.topology.nodepool.spec.auto_scaling`
+
+Required:
+
+- `enabled` (Boolean) Autoscaling config.
+- `min_count` (Number) The minimum number of nodes for autoscaling.
+- `max_count` (Number) The maximum number of nodes for autoscaling.
 
 
 

--- a/internal/models/tanzukubernetescluster/nodepool/nodepool_autoscaling.go
+++ b/internal/models/tanzukubernetescluster/nodepool/nodepool_autoscaling.go
@@ -1,0 +1,46 @@
+/*
+Copyright © 2024 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0
+*/
+
+package tkcnodepool
+
+import (
+	"github.com/go-openapi/swag"
+)
+
+// VmwareTanzuManageV1alpha1ManagementclusterProvisionerTanzukubernetesclusterNodepoolAutoScalingConfig Auto scaling config for the nodepool.
+//
+// swagger:model vmware.tanzu.manage.v1alpha1.managementcluster.provisioner.tanzukubernetescluster.nodepool.AutoScalingConfig
+type VmwareTanzuManageV1alpha1ManagementclusterProvisionerTanzukubernetesclusterNodepoolAutoScalingConfig struct {
+
+	// Whether to enable auto-scaler.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// The maximum number of nodes for auto-scaling.
+	MaxCount int32 `json:"maxCount,omitempty"`
+
+	// The minimum number of nodes for auto-scaling.
+	MinCount int32 `json:"minCount,omitempty"`
+}
+
+// MarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ManagementclusterProvisionerTanzukubernetesclusterNodepoolAutoScalingConfig) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation.
+func (m *VmwareTanzuManageV1alpha1ManagementclusterProvisionerTanzukubernetesclusterNodepoolAutoScalingConfig) UnmarshalBinary(b []byte) error {
+	var res VmwareTanzuManageV1alpha1ManagementclusterProvisionerTanzukubernetesclusterNodepoolAutoScalingConfig
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+
+	*m = res
+
+	return nil
+}

--- a/internal/models/tanzukubernetescluster/nodepool/nodepool_spec.go
+++ b/internal/models/tanzukubernetescluster/nodepool/nodepool_spec.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2023 VMware, Inc. All Rights Reserved.
+Copyright © 2024 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: MPL-2.0
 */
 
@@ -15,6 +15,9 @@ import (
 //
 // swagger:model vmware.tanzu.manage.v1alpha1.managementcluster.provisioner.tanzukubernetescluster.nodepool.Spec
 type VmwareTanzuManageV1alpha1ManagementClusterProvisionerTanzukubernetesClusterNodepoolSpec struct {
+
+	// Auto scaling config.
+	AutoScaling *VmwareTanzuManageV1alpha1ManagementclusterProvisionerTanzukubernetesclusterNodepoolAutoScalingConfig `json:"autoScaling,omitempty"`
 
 	// The name of the machine deployment class used to create the nodepool.
 	Class string `json:"class,omitempty"`

--- a/internal/resources/tanzukubernetescluster/converter_mapping.go
+++ b/internal/resources/tanzukubernetescluster/converter_mapping.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2023 VMware, Inc. All Rights Reserved.
+Copyright © 2024 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: MPL-2.0
 */
 
@@ -49,6 +49,11 @@ var tfModelResourceMap = &tfModelConverterHelper.BlockToStruct{
 							NameKey:    tfModelConverterHelper.BuildDefaultModelPath("spec", "topology", nodePoolsArrayField, "spec", "osImage", "name"),
 							OSArchKey:  tfModelConverterHelper.BuildDefaultModelPath("spec", "topology", nodePoolsArrayField, "spec", "osImage", "arch"),
 							VersionKey: tfModelConverterHelper.BuildDefaultModelPath("spec", "topology", nodePoolsArrayField, "spec", "osImage", "version"),
+						},
+						AutoscalingKey: &tfModelConverterHelper.BlockToStruct{
+							AutoscalingEnabledKey:  tfModelConverterHelper.BuildDefaultModelPath("spec", "topology", nodePoolsArrayField, "spec", "autoScaling", "enabled"),
+							AutoscalingMinCountKey: tfModelConverterHelper.BuildDefaultModelPath("spec", "topology", nodePoolsArrayField, "spec", "autoScaling", "minCount"),
+							AutoscalingMaxCountKey: tfModelConverterHelper.BuildDefaultModelPath("spec", "topology", nodePoolsArrayField, "spec", "autoScaling", "maxCount"),
 						},
 						OverridesKey: &tfModelConverterHelper.EvaluatedField{
 							Field:    tfModelConverterHelper.BuildDefaultModelPath("spec", "topology", nodePoolsArrayField, "spec", tfModelConverterHelper.BuildArrayField("overrides")),

--- a/internal/resources/tanzukubernetescluster/schema.go
+++ b/internal/resources/tanzukubernetescluster/schema.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2023 VMware, Inc. All Rights Reserved.
+Copyright © 2024 VMware, Inc. All Rights Reserved.
 SPDX-License-Identifier: MPL-2.0
 */
 
@@ -59,6 +59,7 @@ const (
 	WorkerClassKey   = "worker_class"
 	FailureDomainKey = "failure_domain"
 	OverridesKey     = "overrides"
+	AutoscalingKey   = "auto_scaling"
 
 	// Network Directive Keys.
 	PodCIDRBlocksKey     = "pod_cidr_blocks"
@@ -68,6 +69,11 @@ const (
 	// Core Addon Directive Keys.
 	TypeKey     = "type"
 	ProviderKey = "provider"
+
+	// Autoscaling Directive Keys.
+	AutoscalingEnabledKey  = "enabled"
+	AutoscalingMinCountKey = "min_count"
+	AutoscalingMaxCountKey = "max_count"
 
 	// Timeout Policy Default Values.
 	TimeoutDefaultValue           = 60
@@ -320,6 +326,32 @@ var NodePoolSpecSchema = &schema.Schema{
 			},
 			ReplicasKey: ReplicasSchema,
 			OSImageKey:  OSImageSchema,
+			AutoscalingKey: {
+				Type:        schema.TypeList,
+				Description: "Autoscaling config on the node pool",
+				MaxItems:    1,
+				Computed:    true,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						AutoscalingEnabledKey: {
+							Type:        schema.TypeBool,
+							Description: "Enable autoscaling.",
+							Required:    true,
+						},
+						AutoscalingMinCountKey: {
+							Type:        schema.TypeInt,
+							Description: "The minimum number of nodes for autoscaling.",
+							Required:    true,
+						},
+						AutoscalingMaxCountKey: {
+							Type:        schema.TypeInt,
+							Description: "The maximum number of nodes for autoscaling.",
+							Required:    true,
+						},
+					},
+				},
+			},
 			common.MetaKey: {
 				Type:        schema.TypeList,
 				Description: "Metadata for the resource",


### PR DESCRIPTION
Add a new block nodepool.spec.auto_scaling, which contains enabled, min_count and max_count to enable/disable the autoscaling on a nodepool.

1. **What this PR does / why we need it**:
TKGS supports auto-scaling from 80u3 (tkg-service 3.0.0), this MR is to expose the feature in terraform cli.
To support this feature from TMC side, a new member in nodepool's spec was added, it contains:
    enabled: true or false to enable/disable auto-scaling on a nodepool
    min_count: minimum number of nodes during auto-scaling
    max_count: maximum number of nodes during auto-scaling

test done:

-    1. create a nodepool with {enabled: true, min_count:1, max_count:2}, to verify the nodepool being created successfully,
-    2. change a nodepool from {enabled: true, min_count:1, max_count:2} to {enabled: false, min_count:0, max_count:0}, to verify auto-scaling being disabled successfully.
-    3. change a nodepool from {enabled: false, min_count:0, max_count:0} to {enabled: true, min_count:1, max_count:2}, to verify auto-scaling being enabled successfully.
-    4. change a nodepool from {enabled: true, min_count:1, max_count:2} to {enabled: true, min_count:2, max_count:3}, to verify the change applied to cluster nodepool.

5. **Which issue(s) this PR fixes**


6. **Additional information**


7. **Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->