### PR TITLE
Handle x-kubernetes-preserve-unknown-fields in import

### DIFF
--- a/internal/helper/openapi_v3_schema_validator/openapi_v3_schema_validator.go
+++ b/internal/helper/openapi_v3_schema_validator/openapi_v3_schema_validator.go
@@ -22,6 +22,7 @@ const (
 	PropertiesKey           OpenAPIV3Key = "properties"
 	TypeKey                 OpenAPIV3Key = "type"
 	AdditionalPropertiesKey OpenAPIV3Key = "additionalProperties"
+	PreserveUnknownFieldKey OpenAPIV3Key = "x-kubernetes-preserve-unknown-fields"
 	ItemsKey                OpenAPIV3Key = "items"
 	PatternKey              OpenAPIV3Key = "pattern"
 	MinLengthKey            OpenAPIV3Key = "minLength"

--- a/internal/resources/tanzukubernetescluster/helper.go
+++ b/internal/resources/tanzukubernetescluster/helper.go
@@ -460,14 +460,16 @@ func removeModelVariable(clusterClassSchema interface{}, modelVariable interface
 				}
 			}
 		} else {
-			modelVarAdditionalProperties := clusterClassSchema.(map[string]interface{})[string(openapiv3.AdditionalPropertiesKey)]
-			_, propertiesExist := modelVarAdditionalProperties.(map[string]interface{})[string(openapiv3.PropertiesKey)]
+			modelVarAdditionalProperties, additionalPropertiesExist := clusterClassSchema.(map[string]interface{})[string(openapiv3.AdditionalPropertiesKey)]
+			if additionalPropertiesExist {
+				_, propertiesExist := modelVarAdditionalProperties.(map[string]interface{})[string(openapiv3.PropertiesKey)]
 
-			if propertiesExist {
-				modelVariable = make(map[string]interface{})
+				if propertiesExist {
+					modelVariable = make(map[string]interface{})
 
-				for k, v := range modelVariableMap {
-					modelVariable.(map[string]interface{})[k] = removeModelVariable(modelVarAdditionalProperties, v)
+					for k, v := range modelVariableMap {
+						modelVariable.(map[string]interface{})[k] = removeModelVariable(modelVarAdditionalProperties, v)
+					}
 				}
 			}
 		}

--- a/internal/resources/tanzukubernetescluster/helper.go
+++ b/internal/resources/tanzukubernetescluster/helper.go
@@ -461,6 +461,7 @@ func removeModelVariable(clusterClassSchema interface{}, modelVariable interface
 			}
 		} else {
 			modelVarAdditionalProperties, additionalPropertiesExist := clusterClassSchema.(map[string]interface{})[string(openapiv3.AdditionalPropertiesKey)]
+			preserve, preserveExists := clusterClassSchema.(map[string]interface{})[string(openapiv3.PreserveUnknownFieldKey)]
 			if additionalPropertiesExist {
 				_, propertiesExist := modelVarAdditionalProperties.(map[string]interface{})[string(openapiv3.PropertiesKey)]
 
@@ -471,6 +472,8 @@ func removeModelVariable(clusterClassSchema interface{}, modelVariable interface
 						modelVariable.(map[string]interface{})[k] = removeModelVariable(modelVarAdditionalProperties, v)
 					}
 				}
+			} else if !preserveExists || !preserve.(bool) {
+				modelVariable = make(map[string]interface{})
 			}
 		}
 	}


### PR DESCRIPTION
1. **What this PR does / why we need it**:

This handles situation where the cluster class spec might not have certain properties fields and instead uses `x-kubernetes-preserve-unknown-fields`
2. **Which issue(s) this PR fixes**

 Fixes https://github.com/vmware/terraform-provider-tanzu-mission-control/issues/419
