### PR TITLE
fixing datasource schema for tanzu kubernetes clusters and adding generic helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore any built binaries.
-terraform-provider-tanzu-mission-control
+terraform-provider-tanzu-mission-control*
 terraform-provider-tanzu-mission-control.exe
 
 # Ignore distribution directories.
@@ -14,3 +14,4 @@ dist/
 
 # Ignore macOS desktop services store files.
 **/.DS_Store
+

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ vet:
 
 # Linter
 lint: gofmt
-	golangci-lint run -c ./.golangci.yml ./internal/... .
+	golangci-lint run -c ./.golangci.yml ./internal/... --timeout 5m
 
 acc-test:
 	go test $(TEST_PKGS) -tags $(BUILD_TAGS)

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -228,6 +228,7 @@ func GetAllMapsKeys(maps ...map[string]interface{}) map[string]bool {
 	return keys
 }
 
+// nolint:godot
 // DatasourceSchemaFromResourceSchema is a recursive func that
 // converts an existing Resource schema to a Datasource schema.
 // All schema elements are copied, but certain attributes are ignored or changed:
@@ -236,6 +237,7 @@ func GetAllMapsKeys(maps ...map[string]interface{}) map[string]bool {
 // - Validation funcs and attributes (e.g. MaxItems) are not copied
 func DatasourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string]*schema.Schema {
 	ds := make(map[string]*schema.Schema, len(rs))
+
 	for k, v := range rs {
 		dv := &schema.Schema{
 			Computed:    true,
@@ -266,11 +268,11 @@ func DatasourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string
 		default:
 			// Elem of all other types are copied as-is
 			dv.Elem = v.Elem
-
 		}
-		ds[k] = dv
 
+		ds[k] = dv
 	}
+
 	return ds
 }
 

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -227,3 +227,77 @@ func GetAllMapsKeys(maps ...map[string]interface{}) map[string]bool {
 
 	return keys
 }
+
+// DatasourceSchemaFromResourceSchema is a recursive func that
+// converts an existing Resource schema to a Datasource schema.
+// All schema elements are copied, but certain attributes are ignored or changed:
+// - all attributes have Computed = true
+// - all attributes have ForceNew, Required = false
+// - Validation funcs and attributes (e.g. MaxItems) are not copied
+func DatasourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string]*schema.Schema {
+	ds := make(map[string]*schema.Schema, len(rs))
+	for k, v := range rs {
+		dv := &schema.Schema{
+			Computed:    true,
+			ForceNew:    false,
+			Required:    false,
+			Description: v.Description,
+			Type:        v.Type,
+		}
+
+		switch v.Type {
+		case schema.TypeSet:
+			dv.Set = v.Set
+			fallthrough
+		case schema.TypeList:
+			// List & Set types are generally used for 2 cases:
+			// - a list/set of simple primitive values (e.g. list of strings)
+			// - a sub resource
+			if elem, ok := v.Elem.(*schema.Resource); ok {
+				// handle the case where the Element is a sub-resource
+				dv.Elem = &schema.Resource{
+					Schema: DatasourceSchemaFromResourceSchema(elem.Schema),
+				}
+			} else {
+				// handle simple primitive case
+				dv.Elem = v.Elem
+			}
+
+		default:
+			// Elem of all other types are copied as-is
+			dv.Elem = v.Elem
+
+		}
+		ds[k] = dv
+
+	}
+	return ds
+}
+
+// fixDatasourceSchemaFlags is a convenience func that toggles the Computed,
+// Optional + Required flags on a schema element. This is useful when the schema
+// has been generated (using `DatasourceSchemaFromResourceSchema` above for
+// example) and therefore the attribute flags were not set appropriately when
+// first added to the schema definition. Currently only supports top-level
+// schema elements.
+func FixDatasourceSchemaFlags(schema map[string]*schema.Schema, required bool, keys ...string) {
+	for _, v := range keys {
+		schema[v].Computed = false
+		schema[v].Optional = !required
+		schema[v].Required = required
+	}
+}
+
+func AddRequiredFieldsToSchema(schema map[string]*schema.Schema, keys ...string) {
+	FixDatasourceSchemaFlags(schema, true, keys...)
+}
+
+func AddOptionalFieldsToSchema(schema map[string]*schema.Schema, keys ...string) {
+	FixDatasourceSchemaFlags(schema, false, keys...)
+}
+
+func DeleteFieldsFromSchema(schema map[string]*schema.Schema, keys ...string) {
+	for _, key := range keys {
+		delete(schema, key)
+	}
+}

--- a/internal/resources/tanzukubernetescluster/data_source.go
+++ b/internal/resources/tanzukubernetescluster/data_source.go
@@ -18,7 +18,6 @@ import (
 )
 
 func DataSourceTanzuKubernetesCluster() *schema.Resource {
-
 	dsSchema := helper.DatasourceSchemaFromResourceSchema(tanzuKubernetesClusterSchema)
 
 	// Set 'Required' schema elements

--- a/internal/resources/tanzukubernetescluster/data_source.go
+++ b/internal/resources/tanzukubernetescluster/data_source.go
@@ -18,11 +18,17 @@ import (
 )
 
 func DataSourceTanzuKubernetesCluster() *schema.Resource {
+
+	dsSchema := helper.DatasourceSchemaFromResourceSchema(tanzuKubernetesClusterSchema)
+
+	// Set 'Required' schema elements
+	helper.AddRequiredFieldsToSchema(dsSchema, "name", "management_cluster_name", "provisioner_name")
+
 	return &schema.Resource{
 		ReadContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 			return dataSourceTanzuKubernetesClusterRead(helper.GetContextWithCaller(ctx, helper.DataRead), d, m)
 		},
-		Schema: tanzuKubernetesClusterSchema,
+		Schema: dsSchema,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	if debugMode {
 		opts.Debug = debugMode
-		opts.ProviderAddr = "vmware/dev/tanzu-mission-control"
+		opts.ProviderAddr = "vmware/tanzu-mission-control"
 	}
 
 	plugin.Serve(opts)


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do not enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.
    For more information, please refer to https://www.conventionalcommits.org.
-->

### Summary

This PR fixes an issue where the data source for tanzu kubernetes clusters had fields that were not being marked as computed and could not be used in other parts of the terraform code. 

This adds a helper that modifies the schema to be specific to datasources . This helper can be re-used for other datasources. The helper is also implemented in the tanzu_kubernetes_cluster datasources

 


### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

no documentation needed since there is no change to the user experience. Tested creating a cluster and getting the data back using the datatsource and ensuring that it could be referenced before the cluster exists

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
