### PR TITLE
chore(tests): fix subnet values for EKS cluster and nodepools

### DIFF
--- a/internal/resources/ekscluster/resource_ekscluster_test.go
+++ b/internal/resources/ekscluster/resource_ekscluster_test.go
@@ -441,9 +441,9 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 					PublicAccessCidrs: []string{
 						"0.0.0.0/0",
 					},
-					SecurityGroups: []string{"sg-0b77767aa25e20fec"},
+					SecurityGroups: []string{"sg-0197c9a8b1378eed5"},
 					SubnetIds: []string{
-						"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9",
+						"subnet-022e4a6bc8c8ee7a6", "subnet-0277c4ea9fc2fd193", "subnet-0d3d1f9c48286ecdf", "subnet-0ec0a74e995ba4634",
 					},
 				},
 			},
@@ -469,7 +469,7 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 						"testnplabelkey": "testnplabelvalue",
 					},
 					SubnetIds: []string{
-						"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9",
+						"subnet-022e4a6bc8c8ee7a6", "subnet-0277c4ea9fc2fd193", "subnet-0d3d1f9c48286ecdf", "subnet-0ec0a74e995ba4634",
 					},
 					ScalingConfig: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolScalingConfig{
 						DesiredSize: 4,
@@ -504,7 +504,7 @@ func getMockEksClusterSpec(accountID string, templateID string) (eksmodel.Vmware
 						"testnplabelkey": "testnplabelvalue",
 					},
 					SubnetIds: []string{
-						"subnet-0c285da60b373a4cc", "subnet-0be854d94fa197cb7", "subnet-04975d535cf761785", "subnet-0d50aa17c694457c9",
+						"subnet-022e4a6bc8c8ee7a6", "subnet-0277c4ea9fc2fd193", "subnet-0d3d1f9c48286ecdf", "subnet-0ec0a74e995ba4634",
 					},
 					LaunchTemplate: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolLaunchTemplate{},
 					ScalingConfig: &eksmodel.VmwareTanzuManageV1alpha1EksclusterNodepoolScalingConfig{


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
Fix subnet values for EKS cluster and nodepools
-->

### Summary

<!--
Fix subnet values for EKS cluster and nodepools
-->

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
